### PR TITLE
Use environment variables for DB credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Sentinel
+
+Este repositório contém o backend em Java Spring Boot e o frontend em React.
+
+## Backend
+
+Antes de executar o backend é necessário definir as variáveis de ambiente `SPRING_DATASOURCE_USERNAME` e `SPRING_DATASOURCE_PASSWORD` com as credenciais do banco de dados. Em seguida utilize o wrapper Maven:
+
+```bash
+./mvnw spring-boot:run
+```
+
+## Frontend
+
+Para executar o frontend:
+
+```bash
+cd frontend
+npm install
+npm start
+```

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,10 +8,10 @@ spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST:localhost}:3306/sentinel_app?useSSL=false&serverTimezone=UTC
 
 #Usuário banco
-spring.datasource.username=root
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 
 #Senha banco
-spring.datasource.password=dL@263093
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
 #Driver Mysql
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## Summary
- reference env vars in `application.properties`
- add README with instructions on setting the vars

## Testing
- `./mvnw -q test` *(fails: failed to fetch apache-maven)*

------
https://chatgpt.com/codex/tasks/task_e_68446b771f28832093838becfa2405a6