### PR TITLE
Add view modal for all tables

### DIFF
--- a/frontend/src/components/TabelaCargos.js
+++ b/frontend/src/components/TabelaCargos.js
@@ -1,6 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 function Tabela({ vetor, selecionar }) {
+    const [cargoSelecionado, setCargoSelecionado] = useState(null);
+
     useEffect(() => {
         // Função para carregar um script externo
         const loadScript = (src) => {
@@ -65,7 +67,15 @@ function Tabela({ vetor, selecionar }) {
         loadScriptsAndInitTable();
     }, []);
 
+    const abrirModal = (cargo) => {
+        setCargoSelecionado(cargo);
+        if (window.$) {
+            window.$("#modalVisualizarCargo").modal("show");
+        }
+    };
+
     return (
+        <>
         <div className="row">
             <div className="col-md-12">
                 <div className="card">
@@ -102,7 +112,8 @@ function Tabela({ vetor, selecionar }) {
 
 
                                             <td>
-                                                <button onClick={() => { selecionar(indice) }} className="btn btn-warning">Selecionar</button>
+                                                <button onClick={() => { selecionar(indice) }} className="btn btn-warning me-2">Selecionar</button>
+                                                <button onClick={() => abrirModal(obj)} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>
                                     ))}
@@ -113,6 +124,26 @@ function Tabela({ vetor, selecionar }) {
                 </div>
             </div>
         </div>
+
+        <div className="modal fade" id="modalVisualizarCargo" tabIndex="-1" aria-hidden="true">
+            <div className="modal-dialog">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        <h5 className="modal-title"><i className="fa fa-briefcase me-2"></i>Detalhes do Cargo</h5>
+                        <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                    </div>
+                    <div className="modal-body">
+                        {cargoSelecionado && (
+                            <p><strong>Nome:</strong> {cargoSelecionado.nome}</p>
+                        )}
+                    </div>
+                    <div className="modal-footer">
+                        <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </>
     );
 }
 

--- a/frontend/src/components/TabelaDisciplinas.js
+++ b/frontend/src/components/TabelaDisciplinas.js
@@ -1,6 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 function Tabela({ vetor, selecionar }) {
+    const [disciplinaSelecionada, setDisciplinaSelecionada] = useState(null);
+
     useEffect(() => {
         // Função para carregar um script externo
         const loadScript = (src) => {
@@ -65,7 +67,15 @@ function Tabela({ vetor, selecionar }) {
         loadScriptsAndInitTable();
     }, []);
 
+    const abrirModal = (disciplina) => {
+        setDisciplinaSelecionada(disciplina);
+        if (window.$) {
+            window.$("#modalVisualizarDisciplina").modal("show");
+        }
+    };
+
     return (
+        <>
         <div className="row">
             <div className="col-md-12">
                 <div className="card">
@@ -104,7 +114,8 @@ function Tabela({ vetor, selecionar }) {
                                             <td>{obj.carga_horaria}</td>
 
                                             <td>
-                                                <button onClick={() => { selecionar(indice) }} className="btn btn-warning">Selecionar</button>
+                                                <button onClick={() => { selecionar(indice) }} className="btn btn-warning me-2">Selecionar</button>
+                                                <button onClick={() => abrirModal(obj)} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>
                                     ))}
@@ -115,6 +126,29 @@ function Tabela({ vetor, selecionar }) {
                 </div>
             </div>
         </div>
+
+        <div className="modal fade" id="modalVisualizarDisciplina" tabIndex="-1" aria-hidden="true">
+            <div className="modal-dialog">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        <h5 className="modal-title"><i className="fa fa-book me-2"></i>Detalhes da Disciplina</h5>
+                        <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                    </div>
+                    <div className="modal-body">
+                        {disciplinaSelecionada && (
+                            <div>
+                                <p><strong>Nome:</strong> {disciplinaSelecionada.nome}</p>
+                                <p><strong>Carga Horária:</strong> {disciplinaSelecionada.carga_horaria}</p>
+                            </div>
+                        )}
+                    </div>
+                    <div className="modal-footer">
+                        <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </>
     );
 }
 

--- a/frontend/src/components/TabelaPermissaoGrupo.js
+++ b/frontend/src/components/TabelaPermissaoGrupo.js
@@ -1,5 +1,16 @@
+import { useState } from "react";
+
 function Tabela({ vetor, selecionar }) {
+    const [grupoSelecionado, setGrupoSelecionado] = useState(null);
+
+    const abrirModal = (grupo) => {
+        setGrupoSelecionado(grupo);
+        if (window.$) {
+            window.$("#modalVisualizarGrupo").modal("show");
+        }
+    };
     return (
+        <>
         <div className="card">
             <div className="card-header">Grupos e Permissões</div>
             <div className="card-body table-responsive">
@@ -23,7 +34,8 @@ function Tabela({ vetor, selecionar }) {
                                         : 'Nenhuma'}
                                 </td>
                                 <td>
-                                    <button onClick={() => selecionar(index)} className="btn btn-sm btn-warning">Selecionar</button>
+                                    <button onClick={() => selecionar(index)} className="btn btn-sm btn-warning me-2">Selecionar</button>
+                                    <button onClick={() => abrirModal(grupo)} className="btn btn-sm btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                 </td>
                             </tr>
                         ))}
@@ -31,6 +43,29 @@ function Tabela({ vetor, selecionar }) {
                 </table>
             </div>
         </div>
+
+        <div className="modal fade" id="modalVisualizarGrupo" tabIndex="-1" aria-hidden="true">
+            <div className="modal-dialog">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        <h5 className="modal-title"><i className="fa fa-users me-2"></i>Detalhes do Grupo</h5>
+                        <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                    </div>
+                    <div className="modal-body">
+                        {grupoSelecionado && (
+                            <div>
+                                <p><strong>Nome:</strong> {grupoSelecionado.nome}</p>
+                                <p><strong>Permissões:</strong> {grupoSelecionado.permissoes && grupoSelecionado.permissoes.length > 0 ? grupoSelecionado.permissoes.map(p => p.nome).join(', ') : 'Nenhuma'}</p>
+                            </div>
+                        )}
+                    </div>
+                    <div className="modal-footer">
+                        <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </>
     );
 }
 

--- a/frontend/src/components/TabelaTurmas.js
+++ b/frontend/src/components/TabelaTurmas.js
@@ -1,6 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 function Tabela({ vetor, selecionar }) {
+    const [turmaSelecionada, setTurmaSelecionada] = useState(null);
+
     useEffect(() => {
         // Função para carregar um script externo
         const loadScript = (src) => {
@@ -65,7 +67,15 @@ function Tabela({ vetor, selecionar }) {
         loadScriptsAndInitTable();
     }, []);
 
+    const abrirModal = (turma) => {
+        setTurmaSelecionada(turma);
+        if (window.$) {
+            window.$("#modalVisualizarTurma").modal("show");
+        }
+    };
+
     return (
+        <>
         <div className="row">
             <div className="col-md-12">
                 <div className="card">
@@ -114,7 +124,8 @@ function Tabela({ vetor, selecionar }) {
 
 
                                             <td>
-                                                <button onClick={() => { selecionar(indice) }} className="btn btn-warning">Selecionar</button>
+                                                <button onClick={() => { selecionar(indice) }} className="btn btn-warning me-2">Selecionar</button>
+                                                <button onClick={() => abrirModal(obj)} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>
                                     ))}
@@ -125,6 +136,32 @@ function Tabela({ vetor, selecionar }) {
                 </div>
             </div>
         </div>
+
+        <div className="modal fade" id="modalVisualizarTurma" tabIndex="-1" aria-hidden="true">
+            <div className="modal-dialog">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        <h5 className="modal-title"><i className="fa fa-users me-2"></i>Detalhes da Turma</h5>
+                        <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                    </div>
+                    <div className="modal-body">
+                        {turmaSelecionada && (
+                            <div>
+                                <p><strong>Nome:</strong> {turmaSelecionada.nome}</p>
+                                <p><strong>Ano:</strong> {turmaSelecionada.ano}</p>
+                                <p><strong>Turno:</strong> {turmaSelecionada.turno}</p>
+                                <p><strong>Sala:</strong> {turmaSelecionada.sala}</p>
+                                <p><strong>Nível de Ensino:</strong> {turmaSelecionada.nivel}</p>
+                            </div>
+                        )}
+                    </div>
+                    <div className="modal-footer">
+                        <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </>
     );
 }
 

--- a/frontend/src/components/TabelaUsuarios.js
+++ b/frontend/src/components/TabelaUsuarios.js
@@ -1,6 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 function Tabela({ vetor, selecionar }) {
+    const [usuarioSelecionado, setUsuarioSelecionado] = useState(null);
+
     useEffect(() => {
         // Função para carregar um script externo
         const loadScript = (src) => {
@@ -65,7 +67,15 @@ function Tabela({ vetor, selecionar }) {
         loadScriptsAndInitTable();
     }, []);
 
+    const abrirModal = (usuario) => {
+        setUsuarioSelecionado(usuario);
+        if (window.$) {
+            window.$("#modalVisualizarUsuario").modal("show");
+        }
+    };
+
     return (
+        <>
         <div className="row">
             <div className="col-md-12">
                 <div className="card">
@@ -104,7 +114,8 @@ function Tabela({ vetor, selecionar }) {
                                             <td>{obj.email}</td>
                                             <td>{obj.permissaoGrupo.nome}</td>
                                             <td>
-                                                <button onClick={() => { selecionar(indice) }} className="btn btn-warning">Selecionar</button>
+                                                <button onClick={() => { selecionar(indice) }} className="btn btn-warning me-2">Selecionar</button>
+                                                <button onClick={() => abrirModal(obj)} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>
                                     ))}
@@ -115,6 +126,31 @@ function Tabela({ vetor, selecionar }) {
                 </div>
             </div>
         </div>
+
+        {/* Modal de visualização */}
+        <div className="modal fade" id="modalVisualizarUsuario" tabIndex="-1" aria-hidden="true">
+            <div className="modal-dialog">
+                <div className="modal-content">
+                    <div className="modal-header">
+                        <h5 className="modal-title"><i className="fa fa-user me-2"></i>Detalhes do Usuário</h5>
+                        <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                    </div>
+                    <div className="modal-body">
+                        {usuarioSelecionado && (
+                            <div>
+                                <p><strong>Nome:</strong> {usuarioSelecionado.nome}</p>
+                                <p><strong>Email:</strong> {usuarioSelecionado.email}</p>
+                                <p><strong>Permissão:</strong> {usuarioSelecionado.permissaoGrupo?.nome}</p>
+                            </div>
+                        )}
+                    </div>
+                    <div className="modal-footer">
+                        <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </>
     );
 }
 


### PR DESCRIPTION
## Summary
- add modal viewing support in `TabelaUsuarios`
- implement visualizer modals for discipline, cargos, turmas, and groups

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447d19ddec8320b6a61454df8d1a45