### PR TITLE
Fix DataTable initialization

### DIFF
--- a/frontend/src/components/TabelaAlunos.js
+++ b/frontend/src/components/TabelaAlunos.js
@@ -18,7 +18,6 @@ function Tabela({ vetor, selecionar }) {
     const [alunoSelecionado, setAlunoSelecionado] = useState(null);
 
     useEffect(() => {
-        // Função para carregar um script externo
         const loadScript = (src) => {
             return new Promise((resolve, reject) => {
                 const script = document.createElement("script");
@@ -32,13 +31,15 @@ function Tabela({ vetor, selecionar }) {
 
         async function loadScriptsAndInitTable() {
             try {
-                await loadScript("/assets/js/core/jquery-3.7.1.min.js");
-                await loadScript("/assets/js/core/popper.min.js");
-                await loadScript("/assets/js/core/bootstrap.min.js");
-                await loadScript("/assets/js/plugin/jquery-scrollbar/jquery.scrollbar.min.js");
-                await loadScript("/assets/js/plugin/datatables/datatables.min.js");
-                await loadScript("/assets/js/kaiadmin.min.js");
-                await loadScript("/assets/js/setting-demo2.js");
+                if (!window.$ || !window.$.fn.DataTable) {
+                    await loadScript("/assets/js/core/jquery-3.7.1.min.js");
+                    await loadScript("/assets/js/core/popper.min.js");
+                    await loadScript("/assets/js/core/bootstrap.min.js");
+                    await loadScript("/assets/js/plugin/jquery-scrollbar/jquery.scrollbar.min.js");
+                    await loadScript("/assets/js/plugin/datatables/datatables.min.js");
+                    await loadScript("/assets/js/kaiadmin.min.js");
+                    await loadScript("/assets/js/setting-demo2.js");
+                }
 
                 setTimeout(() => {
                     if (window.$ && window.$.fn.DataTable) {
@@ -77,7 +78,7 @@ function Tabela({ vetor, selecionar }) {
         }
 
         loadScriptsAndInitTable();
-    }, []);
+    }, [vetor]);
 
     // Abre o modal e seta o aluno selecionado
     const abrirModal = (aluno) => {

--- a/frontend/src/components/TabelaCargos.js
+++ b/frontend/src/components/TabelaCargos.js
@@ -4,7 +4,6 @@ function Tabela({ vetor, selecionar }) {
     const [cargoSelecionado, setCargoSelecionado] = useState(null);
 
     useEffect(() => {
-        // Função para carregar um script externo
         const loadScript = (src) => {
             return new Promise((resolve, reject) => {
                 const script = document.createElement("script");
@@ -19,13 +18,15 @@ function Tabela({ vetor, selecionar }) {
         // Carrega todos os scripts na ordem necessária
         async function loadScriptsAndInitTable() {
             try {
-                await loadScript("/assets/js/core/jquery-3.7.1.min.js");
-                await loadScript("/assets/js/core/popper.min.js");
-                await loadScript("/assets/js/core/bootstrap.min.js");
-                await loadScript("/assets/js/plugin/jquery-scrollbar/jquery.scrollbar.min.js");
-                await loadScript("/assets/js/plugin/datatables/datatables.min.js");
-                await loadScript("/assets/js/kaiadmin.min.js");
-                await loadScript("/assets/js/setting-demo2.js");
+                if (!window.$ || !window.$.fn.DataTable) {
+                    await loadScript("/assets/js/core/jquery-3.7.1.min.js");
+                    await loadScript("/assets/js/core/popper.min.js");
+                    await loadScript("/assets/js/core/bootstrap.min.js");
+                    await loadScript("/assets/js/plugin/jquery-scrollbar/jquery.scrollbar.min.js");
+                    await loadScript("/assets/js/plugin/datatables/datatables.min.js");
+                    await loadScript("/assets/js/kaiadmin.min.js");
+                    await loadScript("/assets/js/setting-demo2.js");
+                }
 
                 // Aguarda renderizar DOM antes de aplicar o DataTable
                 setTimeout(() => {
@@ -65,7 +66,7 @@ function Tabela({ vetor, selecionar }) {
         }
 
         loadScriptsAndInitTable();
-    }, []);
+    }, [vetor]);
 
     const abrirModal = (cargo) => {
         setCargoSelecionado(cargo);

--- a/frontend/src/components/TabelaDisciplinas.js
+++ b/frontend/src/components/TabelaDisciplinas.js
@@ -4,7 +4,6 @@ function Tabela({ vetor, selecionar }) {
     const [disciplinaSelecionada, setDisciplinaSelecionada] = useState(null);
 
     useEffect(() => {
-        // Função para carregar um script externo
         const loadScript = (src) => {
             return new Promise((resolve, reject) => {
                 const script = document.createElement("script");
@@ -19,13 +18,15 @@ function Tabela({ vetor, selecionar }) {
         // Carrega todos os scripts na ordem necessária
         async function loadScriptsAndInitTable() {
             try {
-                await loadScript("/assets/js/core/jquery-3.7.1.min.js");
-                await loadScript("/assets/js/core/popper.min.js");
-                await loadScript("/assets/js/core/bootstrap.min.js");
-                await loadScript("/assets/js/plugin/jquery-scrollbar/jquery.scrollbar.min.js");
-                await loadScript("/assets/js/plugin/datatables/datatables.min.js");
-                await loadScript("/assets/js/kaiadmin.min.js");
-                await loadScript("/assets/js/setting-demo2.js");
+                if (!window.$ || !window.$.fn.DataTable) {
+                    await loadScript("/assets/js/core/jquery-3.7.1.min.js");
+                    await loadScript("/assets/js/core/popper.min.js");
+                    await loadScript("/assets/js/core/bootstrap.min.js");
+                    await loadScript("/assets/js/plugin/jquery-scrollbar/jquery.scrollbar.min.js");
+                    await loadScript("/assets/js/plugin/datatables/datatables.min.js");
+                    await loadScript("/assets/js/kaiadmin.min.js");
+                    await loadScript("/assets/js/setting-demo2.js");
+                }
 
                 // Aguarda renderizar DOM antes de aplicar o DataTable
                 setTimeout(() => {
@@ -65,7 +66,7 @@ function Tabela({ vetor, selecionar }) {
         }
 
         loadScriptsAndInitTable();
-    }, []);
+    }, [vetor]);
 
     const abrirModal = (disciplina) => {
         setDisciplinaSelecionada(disciplina);

--- a/frontend/src/components/TabelaTurmas.js
+++ b/frontend/src/components/TabelaTurmas.js
@@ -4,7 +4,6 @@ function Tabela({ vetor, selecionar }) {
     const [turmaSelecionada, setTurmaSelecionada] = useState(null);
 
     useEffect(() => {
-        // Função para carregar um script externo
         const loadScript = (src) => {
             return new Promise((resolve, reject) => {
                 const script = document.createElement("script");
@@ -19,13 +18,15 @@ function Tabela({ vetor, selecionar }) {
         // Carrega todos os scripts na ordem necessária
         async function loadScriptsAndInitTable() {
             try {
-                await loadScript("/assets/js/core/jquery-3.7.1.min.js");
-                await loadScript("/assets/js/core/popper.min.js");
-                await loadScript("/assets/js/core/bootstrap.min.js");
-                await loadScript("/assets/js/plugin/jquery-scrollbar/jquery.scrollbar.min.js");
-                await loadScript("/assets/js/plugin/datatables/datatables.min.js");
-                await loadScript("/assets/js/kaiadmin.min.js");
-                await loadScript("/assets/js/setting-demo2.js");
+                if (!window.$ || !window.$.fn.DataTable) {
+                    await loadScript("/assets/js/core/jquery-3.7.1.min.js");
+                    await loadScript("/assets/js/core/popper.min.js");
+                    await loadScript("/assets/js/core/bootstrap.min.js");
+                    await loadScript("/assets/js/plugin/jquery-scrollbar/jquery.scrollbar.min.js");
+                    await loadScript("/assets/js/plugin/datatables/datatables.min.js");
+                    await loadScript("/assets/js/kaiadmin.min.js");
+                    await loadScript("/assets/js/setting-demo2.js");
+                }
 
                 // Aguarda renderizar DOM antes de aplicar o DataTable
                 setTimeout(() => {
@@ -65,7 +66,7 @@ function Tabela({ vetor, selecionar }) {
         }
 
         loadScriptsAndInitTable();
-    }, []);
+    }, [vetor]);
 
     const abrirModal = (turma) => {
         setTurmaSelecionada(turma);

--- a/frontend/src/components/TabelaUsuarios.js
+++ b/frontend/src/components/TabelaUsuarios.js
@@ -4,7 +4,6 @@ function Tabela({ vetor, selecionar }) {
     const [usuarioSelecionado, setUsuarioSelecionado] = useState(null);
 
     useEffect(() => {
-        // Função para carregar um script externo
         const loadScript = (src) => {
             return new Promise((resolve, reject) => {
                 const script = document.createElement("script");
@@ -19,13 +18,15 @@ function Tabela({ vetor, selecionar }) {
         // Carrega todos os scripts na ordem necessária
         async function loadScriptsAndInitTable() {
             try {
-                await loadScript("/assets/js/core/jquery-3.7.1.min.js");
-                await loadScript("/assets/js/core/popper.min.js");
-                await loadScript("/assets/js/core/bootstrap.min.js");
-                await loadScript("/assets/js/plugin/jquery-scrollbar/jquery.scrollbar.min.js");
-                await loadScript("/assets/js/plugin/datatables/datatables.min.js");
-                await loadScript("/assets/js/kaiadmin.min.js");
-                await loadScript("/assets/js/setting-demo2.js");
+                if (!window.$ || !window.$.fn.DataTable) {
+                    await loadScript("/assets/js/core/jquery-3.7.1.min.js");
+                    await loadScript("/assets/js/core/popper.min.js");
+                    await loadScript("/assets/js/core/bootstrap.min.js");
+                    await loadScript("/assets/js/plugin/jquery-scrollbar/jquery.scrollbar.min.js");
+                    await loadScript("/assets/js/plugin/datatables/datatables.min.js");
+                    await loadScript("/assets/js/kaiadmin.min.js");
+                    await loadScript("/assets/js/setting-demo2.js");
+                }
 
                 // Aguarda renderizar DOM antes de aplicar o DataTable
                 setTimeout(() => {
@@ -65,7 +66,7 @@ function Tabela({ vetor, selecionar }) {
         }
 
         loadScriptsAndInitTable();
-    }, []);
+    }, [vetor]);
 
     const abrirModal = (usuario) => {
         setUsuarioSelecionado(usuario);


### PR DESCRIPTION
## Summary
- initialize DataTables again whenever data updates

## Testing
- `./mvnw -q test` *(fails: Failed to fetch)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844802328688320a82ff2d7b6d7f6f3