### PR TITLE
Remove redundant select buttons from tables

### DIFF
--- a/frontend/src/components/TabelaAlunos.js
+++ b/frontend/src/components/TabelaAlunos.js
@@ -117,8 +117,7 @@ function Tabela({ vetor, selecionar }) {
                                                 <td>{obj.nome_resp1} ({obj.parentesco_resp1})</td>
                                                 <td>{obj.telefone_resp1}</td>
                                                 <td>
-                                                    <button onClick={() => selecionar(indice)} className="btn btn-warning me-2" title="Selecionar"><i className="fa fa-check"></i></button>
-                                                    <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
+                                                <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                                 </td>
                                             </tr>
                                         ))}

--- a/frontend/src/components/TabelaCargos.js
+++ b/frontend/src/components/TabelaCargos.js
@@ -113,7 +113,6 @@ function Tabela({ vetor, selecionar }) {
 
 
                                             <td>
-                                                <button onClick={() => { selecionar(indice); }} className="btn btn-warning me-2" title="Selecionar"><i className="fa fa-check"></i></button>
                                                 <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>

--- a/frontend/src/components/TabelaDisciplinas.js
+++ b/frontend/src/components/TabelaDisciplinas.js
@@ -115,7 +115,6 @@ function Tabela({ vetor, selecionar }) {
                                             <td>{obj.carga_horaria}</td>
 
                                             <td>
-                                                <button onClick={() => { selecionar(indice); }} className="btn btn-warning me-2" title="Selecionar"><i className="fa fa-check"></i></button>
                                                 <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>

--- a/frontend/src/components/TabelaPermissaoGrupo.js
+++ b/frontend/src/components/TabelaPermissaoGrupo.js
@@ -34,7 +34,6 @@ function Tabela({ vetor, selecionar }) {
                                         : 'Nenhuma'}
                                 </td>
                                 <td>
-                                    <button onClick={() => selecionar(index)} className="btn btn-sm btn-warning me-2" title="Selecionar"><i className="fa fa-check"></i></button>
                                     <button onClick={(e) => { e.stopPropagation(); abrirModal(grupo); }} className="btn btn-sm btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                 </td>
                             </tr>

--- a/frontend/src/components/TabelaTurmas.js
+++ b/frontend/src/components/TabelaTurmas.js
@@ -125,7 +125,6 @@ function Tabela({ vetor, selecionar }) {
 
 
                                             <td>
-                                                <button onClick={() => { selecionar(indice); }} className="btn btn-warning me-2" title="Selecionar"><i className="fa fa-check"></i></button>
                                                 <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>

--- a/frontend/src/components/TabelaUsuarios.js
+++ b/frontend/src/components/TabelaUsuarios.js
@@ -115,7 +115,6 @@ function Tabela({ vetor, selecionar }) {
                                             <td>{obj.email}</td>
                                             <td>{obj.permissaoGrupo.nome}</td>
                                             <td>
-                                                <button onClick={() => { selecionar(indice); }} className="btn btn-warning me-2" title="Selecionar"><i className="fa fa-check"></i></button>
                                                 <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>


### PR DESCRIPTION
## Summary
- clean up DataTables components by dropping select buttons

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844854609088320b8bed3f268561bdf