### PR TITLE
Fix cep_resp1 field handling

### DIFF
--- a/frontend/src/components/FormularioAlunos.js
+++ b/frontend/src/components/FormularioAlunos.js
@@ -175,7 +175,17 @@ function Formulario({
                                     </div>
                                 </div>
                                 <div className="col-md-2">
-                                    <IMaskInput mask="00000-000" className="form-control" name="cep_resp1" value={obj.mesmoEnderecoAluno ? obj.cep : obj.cep_resp1} placeholder="CEP" onAccept={(value) => eventoTeclado({ target: { name: cep_resp1, value } })} disabled={obj.mesmoEnderecoAluno} />
+                                    <IMaskInput
+                                        mask="00000-000"
+                                        className="form-control"
+                                        name="cep_resp1"
+                                        value={obj.mesmoEnderecoAluno ? obj.cep : obj.cep_resp1}
+                                        placeholder="CEP"
+                                        onAccept={(value) =>
+                                            eventoTeclado({ target: { name: 'cep_resp1', value } })
+                                        }
+                                        disabled={obj.mesmoEnderecoAluno}
+                                    />
                                 </div>
                                 <div className="col-md-4">
                                     <input type="text" className="form-control" name="rua_resp1" value={obj.mesmoEnderecoAluno ? obj.rua : obj.rua_resp1} placeholder="Rua" onChange={eventoTeclado} disabled={obj.mesmoEnderecoAluno} />


### PR DESCRIPTION
## Summary
- fix the `cep_resp1` mask input to use the correct name

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684488ebeba08320b0ef25e3c2210a0c