### PR TITLE
Fix table refresh in React pages

### DIFF
--- a/frontend/src/components/TabelaAlunos.js
+++ b/frontend/src/components/TabelaAlunos.js
@@ -108,7 +108,7 @@ function Tabela({ vetor, selecionar }) {
                         </div>
                         <div className="card-body">
                             <div className="table-responsive">
-                                <table id="tabela" className="display table table-striped table-hover">
+                                <table id="tabela" key={vetor.length} className="display table table-striped table-hover">
                                     <thead>
                                         <tr>
                                             <th>#</th>

--- a/frontend/src/components/TabelaCargos.js
+++ b/frontend/src/components/TabelaCargos.js
@@ -96,6 +96,7 @@ function Tabela({ vetor, selecionar }) {
                         <div className="table-responsive">
                             <table
                                 id="tabela"
+                                key={vetor.length}
                                 className="display table table-striped table-hover"
                             >
                                 <thead>

--- a/frontend/src/components/TabelaDisciplinas.js
+++ b/frontend/src/components/TabelaDisciplinas.js
@@ -96,6 +96,7 @@ function Tabela({ vetor, selecionar }) {
                         <div className="table-responsive">
                             <table
                                 id="tabela"
+                                key={vetor.length}
                                 className="display table table-striped table-hover"
                             >
                                 <thead>

--- a/frontend/src/components/TabelaPermissaoGrupo.js
+++ b/frontend/src/components/TabelaPermissaoGrupo.js
@@ -14,7 +14,7 @@ function Tabela({ vetor, selecionar }) {
         <div className="card">
             <div className="card-header">Grupos e Permissões</div>
             <div className="card-body table-responsive">
-                <table className="table table-striped table-hover" id="tabela">
+                <table className="table table-striped table-hover" id="tabela" key={vetor.length}>
                     <thead>
                         <tr>
                             <th>#</th>

--- a/frontend/src/components/TabelaTurmas.js
+++ b/frontend/src/components/TabelaTurmas.js
@@ -96,6 +96,7 @@ function Tabela({ vetor, selecionar }) {
                         <div className="table-responsive">
                             <table
                                 id="tabela"
+                                key={vetor.length}
                                 className="display table table-striped table-hover"
                             >
                                 <thead>

--- a/frontend/src/components/TabelaUsuarios.js
+++ b/frontend/src/components/TabelaUsuarios.js
@@ -96,6 +96,7 @@ function Tabela({ vetor, selecionar }) {
                         <div className="table-responsive">
                             <table
                                 id="tabela"
+                                key={vetor.length}
                                 className="display table table-striped table-hover"
                             >
                                 <thead>


### PR DESCRIPTION
## Summary
- force table re-render by changing key when vector changes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `./mvnw -q test` *(fails: unable to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_684493f5c81c8320b6bebed91dc963dc