### PR TITLE
Fix alerts after confirming modals

### DIFF
--- a/frontend/src/pages/Alunos.jsx
+++ b/frontend/src/pages/Alunos.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import Formulario from "../components/FormularioAlunos";
 import Tabela from "../components/TabelaAlunos";
 import Alert from '../components/Alert';
@@ -64,7 +64,7 @@ function Alunos() {
     const [desabilitarResp2, setDesabilitarResp2] = useState(false);
     const [alertMsg, setAlertMsg] = useState("");
     const [confirmMsg, setConfirmMsg] = useState("");
-    const [confirmAction, setConfirmAction] = useState(() => {});
+    const confirmAction = useRef(() => {});
 
     useEffect(() => {
         buscarAlunos();
@@ -180,7 +180,7 @@ function Alunos() {
     };
 
     const showConfirm = (action, message) => {
-        setConfirmAction(() => action);
+        confirmAction.current = action;
         setConfirmMsg(message);
         window.$('#confirmAluno').modal('show');
     };
@@ -312,7 +312,7 @@ function Alunos() {
 
 
                     <Tabela vetor={alunos} selecionar={selecionarAluno} />
-                    <ConfirmModal id="confirmAluno" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction()} />
+                    <ConfirmModal id="confirmAluno" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction.current()} />
                 </div>
             </div>
         </>

--- a/frontend/src/pages/Cargos.jsx
+++ b/frontend/src/pages/Cargos.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 import Formulario from '../components/FormularioCargos';
 import Tabela from '../components/TabelaCargos';
@@ -20,7 +20,7 @@ function Cargos() {
     const [objCargos, setObjCargos] = useState(cargo);
     const [alertMsg, setAlertMsg] = useState("");
     const [confirmMsg, setConfirmMsg] = useState("");
-    const [confirmAction, setConfirmAction] = useState(() => {});
+    const confirmAction = useRef(() => {});
 
 
 
@@ -46,7 +46,7 @@ function Cargos() {
     }
 
     const showConfirm = (action, message) => {
-        setConfirmAction(() => action);
+        confirmAction.current = action;
         setConfirmMsg(message);
         window.$('#confirmCargo').modal('show');
     }
@@ -252,7 +252,7 @@ function Cargos() {
 
                     />
                     <Tabela vetor={cargos} selecionar={selecionarCargo} />
-                    <ConfirmModal id="confirmCargo" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction()} />
+                    <ConfirmModal id="confirmCargo" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction.current()} />
                 </div>
             </div>
         </>

--- a/frontend/src/pages/Disciplinas.jsx
+++ b/frontend/src/pages/Disciplinas.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 import Formulario from '../components/FormularioDisciplinas';
 import Tabela from '../components/TabelaDisciplinas';
@@ -21,7 +21,7 @@ function Disciplinas() {
     const [objDisciplinas, setObjDisciplinas] = useState(disciplina);
     const [alertMsg, setAlertMsg] = useState("");
     const [confirmMsg, setConfirmMsg] = useState("");
-    const [confirmAction, setConfirmAction] = useState(() => {});
+    const confirmAction = useRef(() => {});
 
 
 
@@ -47,7 +47,7 @@ function Disciplinas() {
     }
 
     const showConfirm = (action, message) => {
-        setConfirmAction(() => action);
+        confirmAction.current = action;
         setConfirmMsg(message);
         window.$('#confirmDisciplina').modal('show');
     }
@@ -254,7 +254,7 @@ function Disciplinas() {
 
                     />
                     <Tabela vetor={disciplinas} selecionar={selecionarDisciplina} />
-                    <ConfirmModal id="confirmDisciplina" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction()} />
+                    <ConfirmModal id="confirmDisciplina" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction.current()} />
                 </div>
             </div>
         </>

--- a/frontend/src/pages/PermissoesGrupo.jsx
+++ b/frontend/src/pages/PermissoesGrupo.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import Formulario from '../components/FormularioPermissaoGrupo';
 import Tabela from '../components/TabelaPermissaoGrupo';
 import Alert from '../components/Alert';
@@ -17,7 +17,7 @@ function PermissoesGrupo() {
     const [objPermissaoGrupo, setObjPermissaoGrupo] = useState(permissaoGrupoInicial);
     const [alertMsg, setAlertMsg] = useState("");
     const [confirmMsg, setConfirmMsg] = useState("");
-    const [confirmAction, setConfirmAction] = useState(() => {});
+    const confirmAction = useRef(() => {});
 
     // Carregar grupos e páginas
     useEffect(() => {
@@ -56,7 +56,7 @@ function PermissoesGrupo() {
     };
 
     const showConfirm = (action, message) => {
-        setConfirmAction(() => action);
+        confirmAction.current = action;
         setConfirmMsg(message);
         window.$('#confirmGrupo').modal('show');
     };
@@ -152,7 +152,7 @@ function PermissoesGrupo() {
                 alterar={() => showConfirm(alterar, 'Deseja alterar o grupo?')}
             />
             <Tabela vetor={grupos} selecionar={selecionarPermissao} />
-            <ConfirmModal id="confirmGrupo" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction()} />
+            <ConfirmModal id="confirmGrupo" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction.current()} />
         </>
     );
 }

--- a/frontend/src/pages/Turmas.jsx
+++ b/frontend/src/pages/Turmas.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 import Formulario from '../components/FormularioTurmas';
 import Tabela from '../components/TabelaTurmas';
@@ -24,7 +24,7 @@ function Turmas() {
     const [objTurmas, setObjTurmas] = useState(turma);
     const [alertMsg, setAlertMsg] = useState("");
     const [confirmMsg, setConfirmMsg] = useState("");
-    const [confirmAction, setConfirmAction] = useState(() => {});
+    const confirmAction = useRef(() => {});
 
 
 
@@ -50,7 +50,7 @@ function Turmas() {
     }
 
     const showConfirm = (action, message) => {
-        setConfirmAction(() => action);
+        confirmAction.current = action;
         setConfirmMsg(message);
         window.$('#confirmTurma').modal('show');
     }
@@ -260,7 +260,7 @@ function Turmas() {
 
                     />
                     <Tabela vetor={turmas} selecionar={selecionarTurma} />
-                    <ConfirmModal id="confirmTurma" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction()} />
+                    <ConfirmModal id="confirmTurma" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction.current()} />
                 </div>
             </div>
         </>

--- a/frontend/src/pages/Usuarios.jsx
+++ b/frontend/src/pages/Usuarios.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 import Formulario from '../components/FormularioUsuarios';
 import Tabela from '../components/TabelaUsuarios';
@@ -23,7 +23,7 @@ function Usuarios() {
     const [gruposPermissao, setGruposPermissao] = useState([]);
     const [alertMsg, setAlertMsg] = useState("");
     const [confirmMsg, setConfirmMsg] = useState("");
-    const [confirmAction, setConfirmAction] = useState(() => {});
+    const confirmAction = useRef(() => {});
 
 
     //UseEfect
@@ -60,7 +60,7 @@ function Usuarios() {
     };
 
     const showConfirm = (action, message) => {
-        setConfirmAction(() => action);
+        confirmAction.current = action;
         setConfirmMsg(message);
         window.$('#confirmUsuario').modal('show');
     };
@@ -282,7 +282,7 @@ function Usuarios() {
                         gruposPermissao={gruposPermissao}
                     />
                     <Tabela vetor={usuarios} selecionar={selecionarUsuario} />
-                    <ConfirmModal id="confirmUsuario" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction()} />
+                    <ConfirmModal id="confirmUsuario" title="Confirmação" message={confirmMsg} onConfirm={() => confirmAction.current()} />
                 </div>
             </div>
         </>


### PR DESCRIPTION
## Summary
- ensure modal confirmations call latest action
- show success alerts after confirming modals

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `sh mvnw test -q` *(fails: maven not found)*

------
https://chatgpt.com/codex/tasks/task_e_684495ecdac8832094b90969ca9588b1