### PR TITLE
Fix useEffect dependency in Alunos page

### DIFF
--- a/frontend/src/pages/Alunos.jsx
+++ b/frontend/src/pages/Alunos.jsx
@@ -262,13 +262,7 @@ function Alunos() {
         setDesabilitarResp2(false);
     };
 
-    const buscarAlunos = useCallback(() => {
-        fetchWithAuth("/listar-alunos")
-            .then(data => setAlunos(data))
-            .catch(error => console.error("Erro ao buscar alunos:", error));
-    }, []);
-
-    const fetchWithAuth = async (url, options = {}) => {
+    const fetchWithAuth = useCallback(async (url, options = {}) => {
         const response = await fetch(`http://localhost:8080${url}`, {
             ...options,
             headers: {
@@ -283,7 +277,13 @@ function Alunos() {
         }
 
         return response.json();
-    };
+    }, []);
+
+    const buscarAlunos = useCallback(() => {
+        fetchWithAuth("/listar-alunos")
+            .then(data => setAlunos(data))
+            .catch(error => console.error("Erro ao buscar alunos:", error));
+    }, [fetchWithAuth]);
 
     return (
         <>


### PR DESCRIPTION
## Summary
- wrap `fetchWithAuth` with `useCallback`
- depend on `fetchWithAuth` when fetching students

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684497bfd16c83209c5ff1fe206a28a0