### PR TITLE
Fix buscarAlunos initialization

### DIFF
--- a/frontend/src/pages/Alunos.jsx
+++ b/frontend/src/pages/Alunos.jsx
@@ -66,9 +66,6 @@ function Alunos() {
     const [confirmMsg, setConfirmMsg] = useState("");
     const confirmAction = useRef(() => {});
 
-    useEffect(() => {
-        buscarAlunos();
-    }, [buscarAlunos]);
 
     useEffect(() => {
         if (sincronizarResp1) {
@@ -284,6 +281,10 @@ function Alunos() {
             .then(data => setAlunos(data))
             .catch(error => console.error("Erro ao buscar alunos:", error));
     }, [fetchWithAuth]);
+
+    useEffect(() => {
+        buscarAlunos();
+    }, [buscarAlunos]);
 
     return (
         <>


### PR DESCRIPTION
## Summary
- fix runtime error by defining `buscarAlunos` before using it in `Alunos` component

## Testing
- `./mvnw -q test` *(fails: Permission denied)*
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684498af64588320a534acc3622aaece