### PR TITLE
Fix DataTables cleanup

### DIFF
--- a/frontend/src/components/TabelaAlunos.js
+++ b/frontend/src/components/TabelaAlunos.js
@@ -45,9 +45,10 @@ function Tabela({ vetor, selecionar }) {
                     if (window.$ && window.$.fn.DataTable) {
                         const tabela = window.$("#tabela");
                         if (window.$.fn.DataTable.isDataTable(tabela)) {
-                            tabela.DataTable().destroy();
+                            tabela.DataTable().destroy(true);
                         }
                         tabela.DataTable({
+                            destroy: true,
                             language: {
                                 sEmptyTable: "Nenhum registro encontrado",
                                 sInfo: "Mostrando de _START_ até _END_ de _TOTAL_ registros",
@@ -83,7 +84,7 @@ function Tabela({ vetor, selecionar }) {
             if (window.$ && window.$.fn.DataTable) {
                 const tabela = window.$("#tabela");
                 if (window.$.fn.DataTable.isDataTable(tabela)) {
-                    tabela.DataTable().destroy();
+                    tabela.DataTable().destroy(true);
                 }
             }
         };

--- a/frontend/src/components/TabelaCargos.js
+++ b/frontend/src/components/TabelaCargos.js
@@ -33,9 +33,10 @@ function Tabela({ vetor, selecionar }) {
                     if (window.$ && window.$.fn.DataTable) {
                         const tabela = window.$("#tabela");
                         if (window.$.fn.DataTable.isDataTable(tabela)) {
-                            tabela.DataTable().destroy();
+                            tabela.DataTable().destroy(true);
                         }
                         tabela.DataTable({
+                            destroy: true,
                             language: {
                                 sEmptyTable: "Nenhum registro encontrado",
                                 sInfo: "Mostrando de _START_ até _END_ de _TOTAL_ registros",
@@ -71,7 +72,7 @@ function Tabela({ vetor, selecionar }) {
             if (window.$ && window.$.fn.DataTable) {
                 const tabela = window.$("#tabela");
                 if (window.$.fn.DataTable.isDataTable(tabela)) {
-                    tabela.DataTable().destroy();
+                    tabela.DataTable().destroy(true);
                 }
             }
         };

--- a/frontend/src/components/TabelaDisciplinas.js
+++ b/frontend/src/components/TabelaDisciplinas.js
@@ -33,9 +33,10 @@ function Tabela({ vetor, selecionar }) {
                     if (window.$ && window.$.fn.DataTable) {
                         const tabela = window.$("#tabela");
                         if (window.$.fn.DataTable.isDataTable(tabela)) {
-                            tabela.DataTable().destroy();
+                            tabela.DataTable().destroy(true);
                         }
                         tabela.DataTable({
+                            destroy: true,
                             language: {
                                 sEmptyTable: "Nenhum registro encontrado",
                                 sInfo: "Mostrando de _START_ até _END_ de _TOTAL_ registros",
@@ -71,7 +72,7 @@ function Tabela({ vetor, selecionar }) {
             if (window.$ && window.$.fn.DataTable) {
                 const tabela = window.$("#tabela");
                 if (window.$.fn.DataTable.isDataTable(tabela)) {
-                    tabela.DataTable().destroy();
+                    tabela.DataTable().destroy(true);
                 }
             }
         };

--- a/frontend/src/components/TabelaTurmas.js
+++ b/frontend/src/components/TabelaTurmas.js
@@ -33,9 +33,10 @@ function Tabela({ vetor, selecionar }) {
                     if (window.$ && window.$.fn.DataTable) {
                         const tabela = window.$("#tabela");
                         if (window.$.fn.DataTable.isDataTable(tabela)) {
-                            tabela.DataTable().destroy();
+                            tabela.DataTable().destroy(true);
                         }
                         tabela.DataTable({
+                            destroy: true,
                             language: {
                                 sEmptyTable: "Nenhum registro encontrado",
                                 sInfo: "Mostrando de _START_ até _END_ de _TOTAL_ registros",
@@ -71,7 +72,7 @@ function Tabela({ vetor, selecionar }) {
             if (window.$ && window.$.fn.DataTable) {
                 const tabela = window.$("#tabela");
                 if (window.$.fn.DataTable.isDataTable(tabela)) {
-                    tabela.DataTable().destroy();
+                    tabela.DataTable().destroy(true);
                 }
             }
         };

--- a/frontend/src/components/TabelaUsuarios.js
+++ b/frontend/src/components/TabelaUsuarios.js
@@ -33,9 +33,10 @@ function Tabela({ vetor, selecionar }) {
                     if (window.$ && window.$.fn.DataTable) {
                         const tabela = window.$("#tabela");
                         if (window.$.fn.DataTable.isDataTable(tabela)) {
-                            tabela.DataTable().destroy();
+                            tabela.DataTable().destroy(true);
                         }
                         tabela.DataTable({
+                            destroy: true,
                             language: {
                                 sEmptyTable: "Nenhum registro encontrado",
                                 sInfo: "Mostrando de _START_ até _END_ de _TOTAL_ registros",
@@ -71,7 +72,7 @@ function Tabela({ vetor, selecionar }) {
             if (window.$ && window.$.fn.DataTable) {
                 const tabela = window.$("#tabela");
                 if (window.$.fn.DataTable.isDataTable(tabela)) {
-                    tabela.DataTable().destroy();
+                    tabela.DataTable().destroy(true);
                 }
             }
         };


### PR DESCRIPTION
## Summary
- ensure DataTable instances remove wrappers on destroy
- reinitialise DataTables with `destroy: true` option

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449e0494a08320b56a1105d3050c54