### PR TITLE
Fix jQuery dependency for tables

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,6 +4,15 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
+// Importação do Bootstrap e do jQuery para suportar modais
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap/dist/js/bootstrap.bundle.min.js';
+import $ from 'jquery';
+
+// Torna o jQuery disponível globalmente para componentes que utilizam window.$
+window.$ = $;
+window.jQuery = $;
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- load Bootstrap and jQuery globally so modals work

## Testing
- `npm test --silent -- --watchAll=false`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844e42955e08320aae27fdcb9afcc1b