### PR TITLE
Fix disappearing tables

### DIFF
--- a/frontend/src/components/hooks/useDataTable.js
+++ b/frontend/src/components/hooks/useDataTable.js
@@ -14,7 +14,7 @@ export default function useDataTable(ref, data) {
     if (!ref.current) return;
     const $table = $(ref.current);
     if ($.fn.DataTable.isDataTable($table)) {
-      $table.DataTable().destroy(true);
+      $table.DataTable().destroy();
     }
     $table.DataTable({
       destroy: true,
@@ -45,7 +45,7 @@ export default function useDataTable(ref, data) {
     });
     return () => {
       if ($.fn.DataTable.isDataTable($table)) {
-        $table.DataTable().destroy(true);
+        $table.DataTable().destroy();
       }
     };
   }, [ref, data]);

--- a/frontend/src/pages/Disciplinas.jsx
+++ b/frontend/src/pages/Disciplinas.jsx
@@ -23,6 +23,10 @@ function Disciplinas() {
     const [confirmMsg, setConfirmMsg] = useState("");
     const confirmAction = useRef(() => {});
 
+    const aoDigitar = (e) => {
+        setObjDisciplinas({ ...objDisciplinas, [e.target.name]: e.target.value });
+    };
+
 
 
 


### PR DESCRIPTION
## Summary
- add missing `aoDigitar` handler to `Disciplinas.jsx`
- destroy DataTables instances without removing DOM nodes

## Testing
- `npm test -- -t TabelaUsuarios`
- `npm start` *(verified startup)*

------
https://chatgpt.com/codex/tasks/task_e_68459e793620832085b7a54ba45dd52e