### PR TITLE
Remove modals from tables

### DIFF
--- a/frontend/src/components/TabelaAlunos.js
+++ b/frontend/src/components/TabelaAlunos.js
@@ -1,22 +1,8 @@
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import useDataTable from "./hooks/useDataTable";
 
-function InfoItem({ icon, label, value }) {
-    return (
-        <div className="mb-2">
-            <strong><i className={`fas fa-${icon} me-2`}></i>{label}:</strong> {value || "-"}
-        </div>
-    );
-}
-
-function formatarData(dataStr) {
-    if (!dataStr) return "-";
-    const data = new Date(dataStr);
-    return data.toLocaleDateString("pt-BR");
-}
 
 function Tabela({ vetor, selecionar }) {
-    const [alunoSelecionado, setAlunoSelecionado] = useState(null);
     const tableRef = useRef(null);
     useDataTable(tableRef, vetor);
 
@@ -24,15 +10,6 @@ function Tabela({ vetor, selecionar }) {
         console.log('TabelaAlunos - vetor atualizado:', vetor);
     }, [vetor]);
 
-    // Abre o modal e seta o aluno selecionado
-    const abrirModal = (aluno) => {
-        console.log('TabelaAlunos - abrirModal:', aluno);
-        setAlunoSelecionado(aluno);
-        // Abre modal com jQuery Bootstrap
-        if (window.$) {
-            window.$("#modalVisualizarAluno").modal("show");
-        }
-    };
 
     return (
         <>
@@ -62,7 +39,6 @@ function Tabela({ vetor, selecionar }) {
                                                 <td>{obj.nome_resp1} ({obj.parentesco_resp1})</td>
                                                 <td>{obj.telefone_resp1}</td>
                                                 <td>
-                                                <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                                 </td>
                                             </tr>
                                         ))}
@@ -74,69 +50,6 @@ function Tabela({ vetor, selecionar }) {
                 </div>
             </div>
 
-            {/* Modal com abas */}
-            <div className="modal fade" id="modalVisualizarAluno" tabIndex="-1" aria-hidden="true">
-                <div className="modal-dialog modal-lg">
-                    <div className="modal-content">
-                        <div className="modal-header">
-                            <h5 className="modal-title"><i className="fas fa-user-graduate me-2"></i>Detalhes do Aluno</h5>
-                            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
-                        </div>
-                        <div className="modal-body">
-                            {alunoSelecionado ? (
-                                <>
-                                    <ul className="nav nav-tabs mb-3" role="tablist">
-                                        <li className="nav-item" role="presentation">
-                                            <button className="nav-link active" data-bs-toggle="tab" data-bs-target="#tabAluno" type="button" role="tab">Aluno</button>
-                                        </li>
-                                        <li className="nav-item" role="presentation">
-                                            <button className="nav-link" data-bs-toggle="tab" data-bs-target="#tabResp1" type="button" role="tab">Responsável 1</button>
-                                        </li>
-                                        <li className="nav-item" role="presentation">
-                                            <button className="nav-link" data-bs-toggle="tab" data-bs-target="#tabResp2" type="button" role="tab">Responsável 2</button>
-                                        </li>
-                                    </ul>
-
-                                    <div className="tab-content">
-                                        <div className="tab-pane fade show active" id="tabAluno" role="tabpanel">
-                                            <InfoItem icon="user" label="Nome" value={alunoSelecionado.nome} />
-                                            <InfoItem icon="calendar" label="Data de Nascimento" value={formatarData(alunoSelecionado.data)} />
-                                            <InfoItem icon="venus-mars" label="Gênero" value={alunoSelecionado.genero} />
-                                            <InfoItem icon="home" label="Endereço" value={`${alunoSelecionado.rua}, ${alunoSelecionado.numero} - ${alunoSelecionado.bairro} - ${alunoSelecionado.cidade}/${alunoSelecionado.estado}`} />
-                                            <InfoItem icon="phone" label="Telefone" value={alunoSelecionado.telefone} />
-                                            <InfoItem icon="envelope" label="Email" value={alunoSelecionado.email} />
-                                            <InfoItem icon="chalkboard-teacher" label="Turma" value={alunoSelecionado.turma?.nome} />
-                                        </div>
-
-                                        <div className="tab-pane fade" id="tabResp1" role="tabpanel">
-                                            <InfoItem icon="user" label="Nome" value={alunoSelecionado.nome_resp1} />
-                                            <InfoItem icon="phone" label="Telefone" value={alunoSelecionado.telefone_resp1} />
-                                            <InfoItem icon="envelope" label="Email" value={alunoSelecionado.email_resp1} />
-                                            <InfoItem icon="id-card" label="CPF" value={alunoSelecionado.cpf_resp1} />
-                                            <InfoItem icon="map-marker-alt" label="Endereço" value={`${alunoSelecionado.rua_resp1}, ${alunoSelecionado.numero_resp1} - ${alunoSelecionado.bairro_resp1} - ${alunoSelecionado.cidade_resp1}/${alunoSelecionado.estado_resp1}`} />
-                                            <InfoItem icon="users" label="Parentesco" value={alunoSelecionado.parentesco_resp1} />
-                                        </div>
-
-                                        <div className="tab-pane fade" id="tabResp2" role="tabpanel">
-                                            <InfoItem icon="user" label="Nome" value={alunoSelecionado.nome_resp2} />
-                                            <InfoItem icon="phone" label="Telefone" value={alunoSelecionado.telefone_resp2} />
-                                            <InfoItem icon="envelope" label="Email" value={alunoSelecionado.email_resp2} />
-                                            <InfoItem icon="id-card" label="CPF" value={alunoSelecionado.cpf_resp2} />
-                                            <InfoItem icon="map-marker-alt" label="Endereço" value={`${alunoSelecionado.rua_resp2}, ${alunoSelecionado.numero_resp2} - ${alunoSelecionado.bairro_resp2} - ${alunoSelecionado.cidade_resp2}/${alunoSelecionado.estado_resp2}`} />
-                                            <InfoItem icon="users" label="Parentesco" value={alunoSelecionado.parentesco_resp2} />
-                                        </div>
-                                    </div>
-                                </>
-                            ) : (
-                                <p>Carregando...</p>
-                            )}
-                        </div>
-                        <div className="modal-footer">
-                            <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
-                        </div>
-                    </div>
-                </div>
-            </div>
         </>
     );
 }

--- a/frontend/src/components/TabelaCargos.js
+++ b/frontend/src/components/TabelaCargos.js
@@ -1,8 +1,7 @@
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import useDataTable from "./hooks/useDataTable";
 
 function Tabela({ vetor, selecionar }) {
-    const [cargoSelecionado, setCargoSelecionado] = useState(null);
     const tableRef = useRef(null);
     useDataTable(tableRef, vetor);
 
@@ -10,13 +9,6 @@ function Tabela({ vetor, selecionar }) {
         console.log('TabelaCargos - vetor atualizado:', vetor);
     }, [vetor]);
 
-    const abrirModal = (cargo) => {
-        console.log('TabelaCargos - abrirModal:', cargo);
-        setCargoSelecionado(cargo);
-        if (window.$) {
-            window.$("#modalVisualizarCargo").modal("show");
-        }
-    };
 
     return (
         <>
@@ -50,32 +42,12 @@ function Tabela({ vetor, selecionar }) {
 
 
                                             <td>
-                                                <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>
                                     ))}
                                 </tbody>
                             </table>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div className="modal fade" id="modalVisualizarCargo" tabIndex="-1" aria-hidden="true">
-            <div className="modal-dialog">
-                <div className="modal-content">
-                    <div className="modal-header">
-                        <h5 className="modal-title"><i className="fa fa-briefcase me-2"></i>Detalhes do Cargo</h5>
-                        <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
-                    </div>
-                    <div className="modal-body">
-                        {cargoSelecionado && (
-                            <p><strong>Nome:</strong> {cargoSelecionado.nome}</p>
-                        )}
-                    </div>
-                    <div className="modal-footer">
-                        <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
                     </div>
                 </div>
             </div>

--- a/frontend/src/components/TabelaDisciplinas.js
+++ b/frontend/src/components/TabelaDisciplinas.js
@@ -1,8 +1,7 @@
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import useDataTable from "./hooks/useDataTable";
 
 function Tabela({ vetor, selecionar }) {
-    const [disciplinaSelecionada, setDisciplinaSelecionada] = useState(null);
     const tableRef = useRef(null);
     useDataTable(tableRef, vetor);
 
@@ -10,13 +9,6 @@ function Tabela({ vetor, selecionar }) {
         console.log('TabelaDisciplinas - vetor atualizado:', vetor);
     }, [vetor]);
 
-    const abrirModal = (disciplina) => {
-        console.log('TabelaDisciplinas - abrirModal:', disciplina);
-        setDisciplinaSelecionada(disciplina);
-        if (window.$) {
-            window.$("#modalVisualizarDisciplina").modal("show");
-        }
-    };
 
     return (
         <>
@@ -51,7 +43,6 @@ function Tabela({ vetor, selecionar }) {
                                             <td>{obj.carga_horaria}</td>
 
                                             <td>
-                                                <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>
                                     ))}
@@ -61,29 +52,6 @@ function Tabela({ vetor, selecionar }) {
                     </div>
                 </div>
             </div>
-        </div>
-
-        <div className="modal fade" id="modalVisualizarDisciplina" tabIndex="-1" aria-hidden="true">
-            <div className="modal-dialog">
-                <div className="modal-content">
-                    <div className="modal-header">
-                        <h5 className="modal-title"><i className="fa fa-book me-2"></i>Detalhes da Disciplina</h5>
-                        <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
-                    </div>
-                    <div className="modal-body">
-                        {disciplinaSelecionada && (
-                            <div>
-                                <p><strong>Nome:</strong> {disciplinaSelecionada.nome}</p>
-                                <p><strong>Carga Horária:</strong> {disciplinaSelecionada.carga_horaria}</p>
-                            </div>
-                        )}
-                    </div>
-                    <div className="modal-footer">
-                        <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
-                    </div>
-                </div>
-            </div>
-        </div>
         </>
     );
 }

--- a/frontend/src/components/TabelaPermissaoGrupo.js
+++ b/frontend/src/components/TabelaPermissaoGrupo.js
@@ -1,8 +1,7 @@
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import useDataTable from "./hooks/useDataTable";
 
 function Tabela({ vetor, selecionar }) {
-    const [grupoSelecionado, setGrupoSelecionado] = useState(null);
     const tableRef = useRef(null);
     useDataTable(tableRef, vetor);
 
@@ -10,13 +9,6 @@ function Tabela({ vetor, selecionar }) {
         console.log('TabelaPermissaoGrupo - vetor atualizado:', vetor);
     }, [vetor]);
 
-    const abrirModal = (grupo) => {
-        console.log('TabelaPermissaoGrupo - abrirModal:', grupo);
-        setGrupoSelecionado(grupo);
-        if (window.$) {
-            window.$("#modalVisualizarGrupo").modal("show");
-        }
-    };
     return (
         <>
         <div className="card">
@@ -42,7 +34,6 @@ function Tabela({ vetor, selecionar }) {
                                         : 'Nenhuma'}
                                 </td>
                                 <td>
-                                    <button onClick={(e) => { e.stopPropagation(); abrirModal(grupo); }} className="btn btn-sm btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                 </td>
                             </tr>
                         ))}
@@ -51,27 +42,6 @@ function Tabela({ vetor, selecionar }) {
             </div>
         </div>
 
-        <div className="modal fade" id="modalVisualizarGrupo" tabIndex="-1" aria-hidden="true">
-            <div className="modal-dialog">
-                <div className="modal-content">
-                    <div className="modal-header">
-                        <h5 className="modal-title"><i className="fa fa-users me-2"></i>Detalhes do Grupo</h5>
-                        <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
-                    </div>
-                    <div className="modal-body">
-                        {grupoSelecionado && (
-                            <div>
-                                <p><strong>Nome:</strong> {grupoSelecionado.nome}</p>
-                                <p><strong>Permissões:</strong> {grupoSelecionado.permissoes && grupoSelecionado.permissoes.length > 0 ? grupoSelecionado.permissoes.map(p => p.nome).join(', ') : 'Nenhuma'}</p>
-                            </div>
-                        )}
-                    </div>
-                    <div className="modal-footer">
-                        <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
-                    </div>
-                </div>
-            </div>
-        </div>
         </>
     );
 }

--- a/frontend/src/components/TabelaTurmas.js
+++ b/frontend/src/components/TabelaTurmas.js
@@ -1,8 +1,7 @@
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import useDataTable from "./hooks/useDataTable";
 
 function Tabela({ vetor, selecionar }) {
-    const [turmaSelecionada, setTurmaSelecionada] = useState(null);
     const tableRef = useRef(null);
     useDataTable(tableRef, vetor);
 
@@ -10,13 +9,6 @@ function Tabela({ vetor, selecionar }) {
         console.log('TabelaTurmas - vetor atualizado:', vetor);
     }, [vetor]);
 
-    const abrirModal = (turma) => {
-        console.log('TabelaTurmas - abrirModal:', turma);
-        setTurmaSelecionada(turma);
-        if (window.$) {
-            window.$("#modalVisualizarTurma").modal("show");
-        }
-    };
 
     return (
         <>
@@ -58,7 +50,6 @@ function Tabela({ vetor, selecionar }) {
 
 
                                             <td>
-                                                <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>
                                     ))}
@@ -68,32 +59,6 @@ function Tabela({ vetor, selecionar }) {
                     </div>
                 </div>
             </div>
-        </div>
-
-        <div className="modal fade" id="modalVisualizarTurma" tabIndex="-1" aria-hidden="true">
-            <div className="modal-dialog">
-                <div className="modal-content">
-                    <div className="modal-header">
-                        <h5 className="modal-title"><i className="fa fa-users me-2"></i>Detalhes da Turma</h5>
-                        <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
-                    </div>
-                    <div className="modal-body">
-                        {turmaSelecionada && (
-                            <div>
-                                <p><strong>Nome:</strong> {turmaSelecionada.nome}</p>
-                                <p><strong>Ano:</strong> {turmaSelecionada.ano}</p>
-                                <p><strong>Turno:</strong> {turmaSelecionada.turno}</p>
-                                <p><strong>Sala:</strong> {turmaSelecionada.sala}</p>
-                                <p><strong>Nível de Ensino:</strong> {turmaSelecionada.nivel}</p>
-                            </div>
-                        )}
-                    </div>
-                    <div className="modal-footer">
-                        <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
-                    </div>
-                </div>
-            </div>
-        </div>
         </>
     );
 }

--- a/frontend/src/components/TabelaUsuarios.js
+++ b/frontend/src/components/TabelaUsuarios.js
@@ -1,8 +1,7 @@
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import useDataTable from "./hooks/useDataTable";
 
 function Tabela({ vetor, selecionar }) {
-    const [usuarioSelecionado, setUsuarioSelecionado] = useState(null);
     const tableRef = useRef(null);
     useDataTable(tableRef, vetor);
 
@@ -10,13 +9,6 @@ function Tabela({ vetor, selecionar }) {
         console.log('TabelaUsuarios - vetor atualizado:', vetor);
     }, [vetor]);
 
-    const abrirModal = (usuario) => {
-        console.log('TabelaUsuarios - abrirModal:', usuario);
-        setUsuarioSelecionado(usuario);
-        if (window.$) {
-            window.$("#modalVisualizarUsuario").modal("show");
-        }
-    };
 
     return (
         <>
@@ -51,7 +43,6 @@ function Tabela({ vetor, selecionar }) {
                                             <td>{obj.email}</td>
                                             <td>{obj.permissaoGrupo.nome}</td>
                                             <td>
-                                                <button onClick={(e) => { e.stopPropagation(); abrirModal(obj); }} className="btn btn-info" title="Visualizar"><i className="fa fa-eye"></i></button>
                                             </td>
                                         </tr>
                                     ))}
@@ -63,29 +54,6 @@ function Tabela({ vetor, selecionar }) {
             </div>
         </div>
 
-        {/* Modal de visualização */}
-        <div className="modal fade" id="modalVisualizarUsuario" tabIndex="-1" aria-hidden="true">
-            <div className="modal-dialog">
-                <div className="modal-content">
-                    <div className="modal-header">
-                        <h5 className="modal-title"><i className="fa fa-user me-2"></i>Detalhes do Usuário</h5>
-                        <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
-                    </div>
-                    <div className="modal-body">
-                        {usuarioSelecionado && (
-                            <div>
-                                <p><strong>Nome:</strong> {usuarioSelecionado.nome}</p>
-                                <p><strong>Email:</strong> {usuarioSelecionado.email}</p>
-                                <p><strong>Permissão:</strong> {usuarioSelecionado.permissaoGrupo?.nome}</p>
-                            </div>
-                        )}
-                    </div>
-                    <div className="modal-footer">
-                        <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
-                    </div>
-                </div>
-            </div>
-        </div>
         </>
     );
 }

--- a/frontend/src/components/modals/ModalAluno.js
+++ b/frontend/src/components/modals/ModalAluno.js
@@ -1,0 +1,76 @@
+import React from 'react';
+
+function InfoItem({ icon, label, value }) {
+  return (
+    <div className="mb-2">
+      <strong><i className={`fas fa-${icon} me-2`}></i>{label}:</strong> {value || "-"}
+    </div>
+  );
+}
+
+function formatarData(dataStr) {
+  if (!dataStr) return "-";
+  const data = new Date(dataStr);
+  return data.toLocaleDateString("pt-BR");
+}
+
+function ModalAluno({ aluno }) {
+  if (!aluno) return null;
+  return (
+    <div className="modal fade" id="modalVisualizarAluno" tabIndex="-1" aria-hidden="true">
+      <div className="modal-dialog modal-lg">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title"><i className="fas fa-user-graduate me-2"></i>Detalhes do Aluno</h5>
+            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+          <div className="modal-body">
+            <ul className="nav nav-tabs mb-3" role="tablist">
+              <li className="nav-item" role="presentation">
+                <button className="nav-link active" data-bs-toggle="tab" data-bs-target="#tabAluno" type="button" role="tab">Aluno</button>
+              </li>
+              <li className="nav-item" role="presentation">
+                <button className="nav-link" data-bs-toggle="tab" data-bs-target="#tabResp1" type="button" role="tab">Responsável 1</button>
+              </li>
+              <li className="nav-item" role="presentation">
+                <button className="nav-link" data-bs-toggle="tab" data-bs-target="#tabResp2" type="button" role="tab">Responsável 2</button>
+              </li>
+            </ul>
+            <div className="tab-content">
+              <div className="tab-pane fade show active" id="tabAluno" role="tabpanel">
+                <InfoItem icon="user" label="Nome" value={aluno.nome} />
+                <InfoItem icon="calendar" label="Data de Nascimento" value={formatarData(aluno.data)} />
+                <InfoItem icon="venus-mars" label="Gênero" value={aluno.genero} />
+                <InfoItem icon="home" label="Endereço" value={`${aluno.rua}, ${aluno.numero} - ${aluno.bairro} - ${aluno.cidade}/${aluno.estado}`} />
+                <InfoItem icon="phone" label="Telefone" value={aluno.telefone} />
+                <InfoItem icon="envelope" label="Email" value={aluno.email} />
+                <InfoItem icon="chalkboard-teacher" label="Turma" value={aluno.turma?.nome} />
+              </div>
+              <div className="tab-pane fade" id="tabResp1" role="tabpanel">
+                <InfoItem icon="user" label="Nome" value={aluno.nome_resp1} />
+                <InfoItem icon="phone" label="Telefone" value={aluno.telefone_resp1} />
+                <InfoItem icon="envelope" label="Email" value={aluno.email_resp1} />
+                <InfoItem icon="id-card" label="CPF" value={aluno.cpf_resp1} />
+                <InfoItem icon="map-marker-alt" label="Endereço" value={`${aluno.rua_resp1}, ${aluno.numero_resp1} - ${aluno.bairro_resp1} - ${aluno.cidade_resp1}/${aluno.estado_resp1}`} />
+                <InfoItem icon="users" label="Parentesco" value={aluno.parentesco_resp1} />
+              </div>
+              <div className="tab-pane fade" id="tabResp2" role="tabpanel">
+                <InfoItem icon="user" label="Nome" value={aluno.nome_resp2} />
+                <InfoItem icon="phone" label="Telefone" value={aluno.telefone_resp2} />
+                <InfoItem icon="envelope" label="Email" value={aluno.email_resp2} />
+                <InfoItem icon="id-card" label="CPF" value={aluno.cpf_resp2} />
+                <InfoItem icon="map-marker-alt" label="Endereço" value={`${aluno.rua_resp2}, ${aluno.numero_resp2} - ${aluno.bairro_resp2} - ${aluno.cidade_resp2}/${aluno.estado_resp2}`} />
+                <InfoItem icon="users" label="Parentesco" value={aluno.parentesco_resp2} />
+              </div>
+            </div>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ModalAluno;

--- a/frontend/src/components/modals/ModalCargo.js
+++ b/frontend/src/components/modals/ModalCargo.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+function ModalCargo({ cargo }) {
+  if (!cargo) return null;
+  return (
+    <div className="modal fade" id="modalVisualizarCargo" tabIndex="-1" aria-hidden="true">
+      <div className="modal-dialog">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title"><i className="fa fa-briefcase me-2"></i>Detalhes do Cargo</h5>
+            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+          <div className="modal-body">
+            <p><strong>Nome:</strong> {cargo.nome}</p>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ModalCargo;

--- a/frontend/src/components/modals/ModalDisciplina.js
+++ b/frontend/src/components/modals/ModalDisciplina.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+function ModalDisciplina({ disciplina }) {
+  if (!disciplina) return null;
+  return (
+    <div className="modal fade" id="modalVisualizarDisciplina" tabIndex="-1" aria-hidden="true">
+      <div className="modal-dialog">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title"><i className="fa fa-book me-2"></i>Detalhes da Disciplina</h5>
+            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+          <div className="modal-body">
+            <div>
+              <p><strong>Nome:</strong> {disciplina.nome}</p>
+              <p><strong>Carga Horária:</strong> {disciplina.carga_horaria}</p>
+            </div>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ModalDisciplina;

--- a/frontend/src/components/modals/ModalGrupo.js
+++ b/frontend/src/components/modals/ModalGrupo.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+function ModalGrupo({ grupo }) {
+  if (!grupo) return null;
+  return (
+    <div className="modal fade" id="modalVisualizarGrupo" tabIndex="-1" aria-hidden="true">
+      <div className="modal-dialog">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title"><i className="fa fa-users me-2"></i>Detalhes do Grupo</h5>
+            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+          <div className="modal-body">
+            <div>
+              <p><strong>Nome:</strong> {grupo.nome}</p>
+              <p><strong>Permissões:</strong> {grupo.permissoes && grupo.permissoes.length > 0 ? grupo.permissoes.map(p => p.nome).join(', ') : 'Nenhuma'}</p>
+            </div>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ModalGrupo;

--- a/frontend/src/components/modals/ModalTurma.js
+++ b/frontend/src/components/modals/ModalTurma.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+function ModalTurma({ turma }) {
+  if (!turma) return null;
+  return (
+    <div className="modal fade" id="modalVisualizarTurma" tabIndex="-1" aria-hidden="true">
+      <div className="modal-dialog">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title"><i className="fa fa-users me-2"></i>Detalhes da Turma</h5>
+            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+          <div className="modal-body">
+            <div>
+              <p><strong>Nome:</strong> {turma.nome}</p>
+              <p><strong>Ano:</strong> {turma.ano}</p>
+              <p><strong>Turno:</strong> {turma.turno}</p>
+              <p><strong>Sala:</strong> {turma.sala}</p>
+              <p><strong>Nível de Ensino:</strong> {turma.nivel}</p>
+            </div>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ModalTurma;

--- a/frontend/src/components/modals/ModalUsuario.js
+++ b/frontend/src/components/modals/ModalUsuario.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+function ModalUsuario({ usuario }) {
+  if (!usuario) return null;
+  return (
+    <div className="modal fade" id="modalVisualizarUsuario" tabIndex="-1" aria-hidden="true">
+      <div className="modal-dialog">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title"><i className="fa fa-user me-2"></i>Detalhes do Usuário</h5>
+            <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+          <div className="modal-body">
+            <div>
+              <p><strong>Nome:</strong> {usuario.nome}</p>
+              <p><strong>Email:</strong> {usuario.email}</p>
+              <p><strong>Permissão:</strong> {usuario.permissaoGrupo?.nome}</p>
+            </div>
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-warning" data-bs-dismiss="modal">Fechar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ModalUsuario;


### PR DESCRIPTION
## Summary
- drop inline view modals from all table components
- keep modal code in dedicated components for later use

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*
- `./mvnw -q test` *(fails: unresolved parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6035a948320a01e94017dab39eb