### PR TITLE
Fix asset imports and update form labels

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,11 +8,13 @@
       "name": "sentinel-front",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.7.2",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "bootstrap": "^5.3.6",
+        "css.gg": "^2.1.4",
         "datatables.net": "^2.3.1",
         "datatables.net-bs5": "^2.3.1",
         "datatables.net-dt": "^2.3.1",
@@ -2474,6 +2476,15 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -6244,6 +6255,12 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "license": "MIT"
+    },
+    "node_modules/css.gg": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/css.gg/-/css.gg-2.1.4.tgz",
+      "integrity": "sha512-7eyhXQLNJus5q3AVlYhDFjvVkB1ng1D9EjaBJzvboLfNx60RcFdZ1NinEgJMEA8bkwPwRLfbZ0ADTBXsbdrRgw==",
+      "license": "SEE LICENSE"
     },
     "node_modules/cssdb": {
       "version": "7.11.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,11 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.7.2",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "bootstrap": "^5.3.6",
+    "css.gg": "^2.1.4",
     "datatables.net": "^2.3.1",
     "datatables.net-bs5": "^2.3.1",
     "datatables.net-dt": "^2.3.1",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -8,8 +8,6 @@
 
   <!-- Favicon -->
   <link rel="icon" href="assets/img/kaiadmin/sentinelLogoIcon.ico" type="image/x-icon" />
-  <link href="https://unpkg.com/css.gg/icons/all.css" rel="stylesheet" />
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
 
 
   <!-- Webfonts -->

--- a/frontend/src/components/FormularioPermissaoGrupo.js
+++ b/frontend/src/components/FormularioPermissaoGrupo.js
@@ -41,8 +41,9 @@ function Formulario({ botao, eventoTeclado, cadastrar, obj, cancelar, excluir, a
                 <div className="card-header">Permissões do Grupo</div>
                 <div className="card-body">
                     <div className="mb-3">
-                        <label>Nome do Grupo</label>
+                        <label htmlFor="nomeGrupo">Nome do Grupo</label>
                         <input
+                            id="nomeGrupo"
                             type="text"
                             value={obj.nome}
                             className="form-control"
@@ -52,7 +53,7 @@ function Formulario({ botao, eventoTeclado, cadastrar, obj, cancelar, excluir, a
                     </div>
 
                     <div className="mb-3">
-                        <label>Permissões</label>
+                        <span className="form-label">Permissões</span>
                         <div className="row">
                             {paginas.map((p) => (
                                 <div key={p.id} className="col-md-6">

--- a/frontend/src/components/hooks/useDataTable.js
+++ b/frontend/src/components/hooks/useDataTable.js
@@ -1,12 +1,16 @@
 import { useLayoutEffect } from 'react';
 import $ from 'jquery';
-import 'datatables.net-bs5';
-import 'datatables.net-responsive-bs5';
+import DataTable from 'datatables.net-bs5';
+import DataTableResponsive from 'datatables.net-responsive-bs5';
 
 if (!window.$) {
   window.$ = $;
   window.jQuery = $;
 }
+
+// Register DataTable plugins with jQuery instance
+DataTable(window, $);
+DataTableResponsive(window, $);
 
 export default function useDataTable(ref, data) {
   useLayoutEffect(() => {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -10,6 +10,8 @@ import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import $ from 'jquery';
 import 'datatables.net-bs5/css/dataTables.bootstrap5.min.css';
 import 'datatables.net-responsive-bs5/css/responsive.bootstrap5.min.css';
+import 'css.gg/icons/all.css';
+import '@fortawesome/fontawesome-free/css/all.min.css';
 
 // Torna o jQuery disponível globalmente para componentes que utilizam window.$
 window.$ = $;


### PR DESCRIPTION
## Summary
- load icon fonts locally instead of from external CDNs
- register DataTables plugins and expose icon fonts
- fix accessibility warnings in `FormularioPermissaoGrupo`
- include new CSS dependencies

## Testing
- `npm test -- -u`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6846fa055a1c8320b8e7562c7d2b794f