### PR TITLE
Pin css.gg version for CSS icons

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "bootstrap": "^5.3.6",
-        "css.gg": "^2.1.4",
+        "css.gg": "2.0.0",
         "datatables.net": "^2.3.1",
         "datatables.net-bs5": "^2.3.1",
         "datatables.net-dt": "^2.3.1",
@@ -6257,10 +6257,10 @@
       "license": "MIT"
     },
     "node_modules/css.gg": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/css.gg/-/css.gg-2.1.4.tgz",
-      "integrity": "sha512-7eyhXQLNJus5q3AVlYhDFjvVkB1ng1D9EjaBJzvboLfNx60RcFdZ1NinEgJMEA8bkwPwRLfbZ0ADTBXsbdrRgw==",
-      "license": "SEE LICENSE"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css.gg/-/css.gg-2.0.0.tgz",
+      "integrity": "sha512-8qO59kSXLbewo7xaUM4eC8328MTdGmb8atpmw6PRzeDGsZrCkAVjJzKeFDIntagl1/aCee+NG1OQtIvWAjgG/A==",
+      "license": "MIT"
     },
     "node_modules/cssdb": {
       "version": "7.11.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "bootstrap": "^5.3.6",
-    "css.gg": "^2.1.4",
+    "css.gg": "2.0.0",
     "datatables.net": "^2.3.1",
     "datatables.net-bs5": "^2.3.1",
     "datatables.net-dt": "^2.3.1",


### PR DESCRIPTION
## Summary
- pin css.gg dependency to 2.0.0 so that `icons/all.css` exists

## Testing
- `npm install`
- `npm test -- --watchAll=false`
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684727d2cd048320a8e64472b2dc64e5