### PR TITLE
Fix datatable window property error

### DIFF
--- a/frontend/src/components/hooks/useDataTable.js
+++ b/frontend/src/components/hooks/useDataTable.js
@@ -1,16 +1,11 @@
 import { useLayoutEffect } from 'react';
 import $ from 'jquery';
 import DataTable from 'datatables.net-bs5';
-import DataTableResponsive from 'datatables.net-responsive-bs5';
+import 'datatables.net-responsive-bs5';
 
-if (!window.$) {
-  window.$ = $;
-  window.jQuery = $;
-}
-
-// Register DataTable plugins with jQuery instance
-DataTable(window, $);
-DataTableResponsive(window, $);
+// jQuery já é utilizado internamente pelo DataTables através dos módulos
+// importados acima, portanto não é necessário registrá-lo manualmente com o
+// objeto `window`, o que causava erro em alguns ambientes.
 
 export default function useDataTable(ref, data) {
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary
- remove manual DataTables registration to prevent window assignment error

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684733a36d7c8320ace7939ab5a75339