### PR TITLE
Unify table components with simple markup

### DIFF
--- a/frontend/src/components/TabelaAlunos.js
+++ b/frontend/src/components/TabelaAlunos.js
@@ -1,60 +1,27 @@
-import { useRef, useEffect } from "react";
-import useDataTable from "./hooks/useDataTable";
-
-
-function Tabela({ vetor, selecionar }) {
-    const tableRef = useRef(null);
-    useDataTable(tableRef, vetor);
-
-    useEffect(() => {
-        console.log('TabelaAlunos - vetor atualizado:', vetor);
-    }, [vetor]);
-
-
+function Tabela({ vetor }) {
     return (
-        <>
-            <div className="row">
-                <div className="col-md-12">
-                    <div className="card">
-                        <div className="card-header">
-                            <h4 className="card-title">Lista de Alunos</h4>
-                        </div>
-                        <div className="card-body">
-                            <div className="table-responsive">
-                                <table
-                                    id="tabela-alunos"
-                                    className="table table-striped table-hover"
-                                    ref={tableRef}
-                                >
-                                    <thead>
-                                        <tr>
-                                            <th>#</th>
-                                            <th>Nome</th>
-                                            <th>Responsável</th>
-                                            <th>Tel Resp1</th>
-                                            <th>Ações</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {vetor.map((obj, indice) => (
-                                            <tr key={obj.id} onClick={() => selecionar(indice)} style={{ cursor: 'pointer' }}>
-                                                <td>{indice + 1}</td>
-                                                <td>{obj.nome}</td>
-                                                <td>{obj.nome_resp1} ({obj.parentesco_resp1})</td>
-                                                <td>{obj.telefone_resp1}</td>
-                                                <td>
-                                                </td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-        </>
+        <table className="table">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Nome</th>
+                    <th>Responsável</th>
+                    <th>Tel Resp1</th>
+                    <th>Ações</th>
+                </tr>
+            </thead>
+            <tbody>
+                {vetor.map((obj, indice) => (
+                    <tr key={obj.id}>
+                        <td>{indice + 1}</td>
+                        <td>{obj.nome}</td>
+                        <td>{obj.nome_resp1} ({obj.parentesco_resp1})</td>
+                        <td>{obj.telefone_resp1}</td>
+                        <td></td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
     );
 }
 

--- a/frontend/src/components/TabelaCargos.js
+++ b/frontend/src/components/TabelaCargos.js
@@ -1,57 +1,23 @@
-import { useRef, useEffect } from "react";
-import useDataTable from "./hooks/useDataTable";
-
-function Tabela({ vetor, selecionar }) {
-    const tableRef = useRef(null);
-    useDataTable(tableRef, vetor);
-
-    useEffect(() => {
-        console.log('TabelaCargos - vetor atualizado:', vetor);
-    }, [vetor]);
-
-
+function Tabela({ vetor }) {
     return (
-        <>
-            <div className="row">
-                <div className="col-md-12">
-                    <div className="card">
-                        <div className="card-header">
-                            <h4 className="card-title">Lista de Cargos</h4>
-                        </div>
-                        <div className="card-body">
-                            <div className="table-responsive">
-                                <table
-                                    id="tabela-cargos"
-                                    className="table table-striped table-hover"
-                                    ref={tableRef}
-                                >
-                                    <thead>
-                                        <tr>
-                                            <th>#</th>
-                                            <th>Nome</th>
-                                            <th>Ações</th>
-
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {vetor.map((obj, indice) => (
-                                            <tr key={obj.id} onClick={() => { selecionar(indice); }} style={{ cursor: 'pointer' }}>
-                                                <td>{indice + 1}</td>
-                                                <td>{obj.nome}</td>
-
-
-                                                <td>
-                                                </td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </>
+        <table className="table">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Nome</th>
+                    <th>Ações</th>
+                </tr>
+            </thead>
+            <tbody>
+                {vetor.map((obj, indice) => (
+                    <tr key={obj.id}>
+                        <td>{indice + 1}</td>
+                        <td>{obj.nome}</td>
+                        <td></td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
     );
 }
 

--- a/frontend/src/components/TabelaPermissaoGrupo.js
+++ b/frontend/src/components/TabelaPermissaoGrupo.js
@@ -1,55 +1,29 @@
-import { useRef, useEffect } from "react";
-import useDataTable from "./hooks/useDataTable";
-
-function Tabela({ vetor, selecionar }) {
-    const tableRef = useRef(null);
-    useDataTable(tableRef, vetor);
-
-    useEffect(() => {
-        console.log('TabelaPermissaoGrupo - vetor atualizado:', vetor);
-    }, [vetor]);
-
+function Tabela({ vetor }) {
     return (
-        <>
-            <div className="card">
-                <div className="card-header">Grupos e Permissões</div>
-                <div className="card-body table-responsive">
-                    <table
-                        id="tabela-permissao-grupo"
-                        className="table table-striped table-hover"
-                        ref={tableRef}
-                    >
-                        <thead>
-                            <tr>
-                                <th>#</th>
-                                <th>Nome do Grupo</th>
-                                <th>Permissões</th>
-                                <th>Ações</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {vetor.map((grupo, index) => (
-                                <tr
-                                    key={grupo.id}
-                                    onClick={() => selecionar(index)}
-                                    style={{ cursor: 'pointer' }}
-                                >
-                                    <td>{index + 1}</td>
-                                    <td>{grupo.nome}</td>
-                                    <td>
-                                        {grupo.permissoes && grupo.permissoes.length > 0
-                                            ? grupo.permissoes.map((p) => p.nome).join(', ')
-                                            : 'Nenhuma'}
-                                    </td>
-                                    <td></td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-
-        </>
+        <table className="table">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Nome do Grupo</th>
+                    <th>Permissões</th>
+                    <th>Ações</th>
+                </tr>
+            </thead>
+            <tbody>
+                {vetor.map((grupo, index) => (
+                    <tr key={grupo.id}>
+                        <td>{index + 1}</td>
+                        <td>{grupo.nome}</td>
+                        <td>
+                            {grupo.permissoes && grupo.permissoes.length > 0
+                                ? grupo.permissoes.map((p) => p.nome).join(', ')
+                                : 'Nenhuma'}
+                        </td>
+                        <td></td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
     );
 }
 

--- a/frontend/src/components/TabelaTurmas.js
+++ b/frontend/src/components/TabelaTurmas.js
@@ -1,70 +1,31 @@
-import { useRef, useEffect } from "react";
-import useDataTable from "./hooks/useDataTable";
-
-function Tabela({ vetor, selecionar }) {
-    const tableRef = useRef(null);
-    useDataTable(tableRef, vetor);
-
-    useEffect(() => {
-        console.log('TabelaTurmas - vetor atualizado:', vetor);
-    }, [vetor]);
-
-
+function Tabela({ vetor }) {
     return (
-        <>
-            <div className="row">
-                <div className="col-md-12">
-                    <div className="card">
-                        <div className="card-header">
-                            <h4 className="card-title">Lista de Turmas</h4>
-                        </div>
-                        <div className="card-body">
-                            <div className="table-responsive">
-                                <table
-                                    id="tabela-turmas"
-                                    className="table table-striped table-hover"
-                                    ref={tableRef}
-                                >
-                                    <thead>
-                                        <tr>
-                                            <th>#</th>
-                                            <th>Nome</th>
-                                            <th>Ano</th>
-                                            <th>Turno</th>
-                                            <th>Sala</th>
-                                            <th>Nivel de Ensino</th>
-                                            <th>Ações</th>
-
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {vetor.map((obj, indice) => (
-                                            <tr
-                                                key={obj.id}
-                                                onClick={() => {
-                                                    selecionar(indice);
-                                                }}
-                                                style={{ cursor: 'pointer' }}
-                                            >
-                                                <td>{indice + 1}</td>
-                                                <td>{obj.nome}</td>
-                                                <td>{obj.ano}</td>
-                                                <td>{obj.turno}</td>
-                                                <td>{obj.sala}</td>
-                                                <td>{obj.nivel}</td>
-
-
-                                                <td></td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </>
+        <table className="table">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Nome</th>
+                    <th>Ano</th>
+                    <th>Turno</th>
+                    <th>Sala</th>
+                    <th>Nivel de Ensino</th>
+                    <th>Ações</th>
+                </tr>
+            </thead>
+            <tbody>
+                {vetor.map((obj, indice) => (
+                    <tr key={obj.id}>
+                        <td>{indice + 1}</td>
+                        <td>{obj.nome}</td>
+                        <td>{obj.ano}</td>
+                        <td>{obj.turno}</td>
+                        <td>{obj.sala}</td>
+                        <td>{obj.nivel}</td>
+                        <td></td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
     );
 }
 

--- a/frontend/src/components/TabelaUsuarios.js
+++ b/frontend/src/components/TabelaUsuarios.js
@@ -1,64 +1,27 @@
-import { useRef, useEffect } from "react";
-import useDataTable from "./hooks/useDataTable";
-
-function Tabela({ vetor, selecionar }) {
-    const tableRef = useRef(null);
-    useDataTable(tableRef, vetor);
-
-    useEffect(() => {
-        console.log('TabelaUsuarios - vetor atualizado:', vetor);
-    }, [vetor]);
-
-
+function Tabela({ vetor }) {
     return (
-        <>
-            <div className="row">
-                <div className="col-md-12">
-                    <div className="card">
-                        <div className="card-header">
-                            <h4 className="card-title">Lista de Usuários</h4>
-                        </div>
-                        <div className="card-body">
-                            <div className="table-responsive">
-                                <table
-                                    id="tabela-usuarios"
-                                    className="table table-striped table-hover"
-                                    ref={tableRef}
-                                >
-                                    <thead>
-                                        <tr>
-                                            <th>#</th>
-                                            <th>Nome</th>
-                                            <th>Email</th>
-                                            <th>Permissão</th>
-                                            <th>Ações</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {vetor.map((obj, indice) => (
-                                            <tr
-                                                key={obj.id}
-                                                onClick={() => {
-                                                    selecionar(indice);
-                                                }}
-                                                style={{ cursor: 'pointer' }}
-                                            >
-                                                <td>{indice + 1}</td>
-                                                <td>{obj.nome}</td>
-                                                <td>{obj.email}</td>
-                                                <td>{obj.permissaoGrupo.nome}</td>
-                                                <td></td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-        </>
+        <table className="table">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Nome</th>
+                    <th>Email</th>
+                    <th>Permissão</th>
+                    <th>Ações</th>
+                </tr>
+            </thead>
+            <tbody>
+                {vetor.map((obj, indice) => (
+                    <tr key={obj.id}>
+                        <td>{indice + 1}</td>
+                        <td>{obj.nome}</td>
+                        <td>{obj.email}</td>
+                        <td>{obj.permissaoGrupo.nome}</td>
+                        <td></td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
     );
 }
 


### PR DESCRIPTION
## Summary
- simplify table components to match the Disciplinas table layout

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848265469c88320b3952c60296af9a5