### PR TITLE
Enable search, sort and pagination without breaking tables

### DIFF
--- a/frontend/src/components/Pagination.js
+++ b/frontend/src/components/Pagination.js
@@ -1,0 +1,20 @@
+function Pagination({ page, pageCount, changePage }) {
+  if (pageCount <= 1) return null;
+  const pages = Array.from({ length: pageCount }, (_, i) => i + 1);
+  return (
+    <nav>
+      <ul className="pagination">
+        <li className={`page-item ${page === 1 ? 'disabled' : ''}`}>\
+<button className="page-link" onClick={() => changePage(page - 1)}>Anterior</button></li>
+        {pages.map(p => (
+          <li key={p} className={`page-item ${p === page ? 'active' : ''}`}>\
+<button className="page-link" onClick={() => changePage(p)}>{p}</button></li>
+        ))}
+        <li className={`page-item ${page === pageCount ? 'disabled' : ''}`}>\
+<button className="page-link" onClick={() => changePage(page + 1)}>Próximo</button></li>
+      </ul>
+    </nav>
+  );
+}
+
+export default Pagination;

--- a/frontend/src/components/TabelaAlunos.js
+++ b/frontend/src/components/TabelaAlunos.js
@@ -1,27 +1,58 @@
+import Pagination from './Pagination';
+import useTableControls from './hooks/useTableControls';
+
 function Tabela({ vetor }) {
+    const {
+        search,
+        setSearch,
+        requestSort,
+        sortConfig,
+        paginated,
+        page,
+        changePage,
+        pageCount,
+    } = useTableControls(vetor, { keys: ['nome', 'nome_resp1', 'telefone_resp1'] });
+
+    const getArrow = (key) => {
+        if (sortConfig.key !== key) return '';
+        return sortConfig.direction === 'asc' ? ' \u25B2' : ' \u25BC';
+    };
+
     return (
-        <table className="table">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Nome</th>
-                    <th>Responsável</th>
-                    <th>Tel Resp1</th>
-                    <th>Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                {vetor.map((obj, indice) => (
-                    <tr key={obj.id}>
-                        <td>{indice + 1}</td>
-                        <td>{obj.nome}</td>
-                        <td>{obj.nome_resp1} ({obj.parentesco_resp1})</td>
-                        <td>{obj.telefone_resp1}</td>
-                        <td></td>
+        <div>
+            <div className="d-flex justify-content-end mb-2">
+                <input
+                    type="text"
+                    className="form-control w-auto"
+                    placeholder="Buscar"
+                    value={search}
+                    onChange={(e) => { setSearch(e.target.value); changePage(1); }}
+                />
+            </div>
+            <table className="table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('nome')}>Nome{getArrow('nome')}</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('nome_resp1')}>Responsável{getArrow('nome_resp1')}</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('telefone_resp1')}>Tel Resp1{getArrow('telefone_resp1')}</th>
+                        <th>Ações</th>
                     </tr>
-                ))}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {paginated.map((obj, indice) => (
+                        <tr key={obj.id}>
+                            <td>{(page - 1) * 5 + indice + 1}</td>
+                            <td>{obj.nome}</td>
+                            <td>{obj.nome_resp1} ({obj.parentesco_resp1})</td>
+                            <td>{obj.telefone_resp1}</td>
+                            <td></td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            <Pagination page={page} pageCount={pageCount} changePage={changePage} />
+        </div>
     );
 }
 

--- a/frontend/src/components/TabelaCargos.js
+++ b/frontend/src/components/TabelaCargos.js
@@ -1,23 +1,54 @@
+import Pagination from './Pagination';
+import useTableControls from './hooks/useTableControls';
+
 function Tabela({ vetor }) {
+    const {
+        search,
+        setSearch,
+        requestSort,
+        sortConfig,
+        paginated,
+        page,
+        changePage,
+        pageCount,
+    } = useTableControls(vetor, { keys: ['nome'] });
+
+    const getArrow = (key) => {
+        if (sortConfig.key !== key) return '';
+        return sortConfig.direction === 'asc' ? ' \u25B2' : ' \u25BC';
+    };
+
     return (
-        <table className="table">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Nome</th>
-                    <th>Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                {vetor.map((obj, indice) => (
-                    <tr key={obj.id}>
-                        <td>{indice + 1}</td>
-                        <td>{obj.nome}</td>
-                        <td></td>
+        <div>
+            <div className="d-flex justify-content-end mb-2">
+                <input
+                    type="text"
+                    className="form-control w-auto"
+                    placeholder="Buscar"
+                    value={search}
+                    onChange={(e) => { setSearch(e.target.value); changePage(1); }}
+                />
+            </div>
+            <table className="table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('nome')}>Nome{getArrow('nome')}</th>
+                        <th>Ações</th>
                     </tr>
-                ))}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {paginated.map((obj, indice) => (
+                        <tr key={obj.id}>
+                            <td>{(page - 1) * 5 + indice + 1}</td>
+                            <td>{obj.nome}</td>
+                            <td></td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            <Pagination page={page} pageCount={pageCount} changePage={changePage} />
+        </div>
     );
 }
 

--- a/frontend/src/components/TabelaDisciplinas.js
+++ b/frontend/src/components/TabelaDisciplinas.js
@@ -1,37 +1,56 @@
-
+import Pagination from './Pagination';
+import useTableControls from './hooks/useTableControls';
 
 function Tabela({ vetor }) {
+    const {
+        search,
+        setSearch,
+        requestSort,
+        sortConfig,
+        paginated,
+        page,
+        changePage,
+        pageCount,
+    } = useTableControls(vetor, { keys: ['nome', 'carga_horaria'] });
 
-
-
-
+    const getArrow = (key) => {
+        if (sortConfig.key !== key) return '';
+        return sortConfig.direction === 'asc' ? ' \u25B2' : ' \u25BC';
+    };
 
     return (
-        <table className="table">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Nome</th>
-                    <th>Carga Horaria</th>
-                    <th>Ações</th>
-                </tr>
-            </thead>
-
-
-            <tbody>
-                {
-                    vetor.map((obj, indice) => (
+        <div>
+            <div className="d-flex justify-content-end mb-2">
+                <input
+                    type="text"
+                    className="form-control w-auto"
+                    placeholder="Buscar"
+                    value={search}
+                    onChange={(e) => { setSearch(e.target.value); changePage(1); }}
+                />
+            </div>
+            <table className="table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('nome')}>Nome{getArrow('nome')}</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('carga_horaria')}>Carga Horaria{getArrow('carga_horaria')}</th>
+                        <th>Ações</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {paginated.map((obj, indice) => (
                         <tr key={indice}>
-                            <td>{indice + 1}</td>
+                            <td>{(page - 1) * 5 + indice + 1}</td>
                             <td>{obj.nome}</td>
                             <td>{obj.carga_horaria}</td>
                             <td><button className="btn"> Selecionar</button></td>
-
                         </tr>
-                    ))
-                }
-            </tbody>
-        </table>
+                    ))}
+                </tbody>
+            </table>
+            <Pagination page={page} pageCount={pageCount} changePage={changePage} />
+        </div>
     );
 }
 

--- a/frontend/src/components/TabelaPermissaoGrupo.js
+++ b/frontend/src/components/TabelaPermissaoGrupo.js
@@ -1,29 +1,60 @@
+import Pagination from './Pagination';
+import useTableControls from './hooks/useTableControls';
+
 function Tabela({ vetor }) {
+    const {
+        search,
+        setSearch,
+        requestSort,
+        sortConfig,
+        paginated,
+        page,
+        changePage,
+        pageCount,
+    } = useTableControls(vetor, { keys: ['nome'] });
+
+    const getArrow = (key) => {
+        if (sortConfig.key !== key) return '';
+        return sortConfig.direction === 'asc' ? ' \u25B2' : ' \u25BC';
+    };
+
     return (
-        <table className="table">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Nome do Grupo</th>
-                    <th>Permissões</th>
-                    <th>Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                {vetor.map((grupo, index) => (
-                    <tr key={grupo.id}>
-                        <td>{index + 1}</td>
-                        <td>{grupo.nome}</td>
-                        <td>
-                            {grupo.permissoes && grupo.permissoes.length > 0
-                                ? grupo.permissoes.map((p) => p.nome).join(', ')
-                                : 'Nenhuma'}
-                        </td>
-                        <td></td>
+        <div>
+            <div className="d-flex justify-content-end mb-2">
+                <input
+                    type="text"
+                    className="form-control w-auto"
+                    placeholder="Buscar"
+                    value={search}
+                    onChange={(e) => { setSearch(e.target.value); changePage(1); }}
+                />
+            </div>
+            <table className="table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('nome')}>Nome do Grupo{getArrow('nome')}</th>
+                        <th>Permissões</th>
+                        <th>Ações</th>
                     </tr>
-                ))}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {paginated.map((grupo, index) => (
+                        <tr key={grupo.id}>
+                            <td>{(page - 1) * 5 + index + 1}</td>
+                            <td>{grupo.nome}</td>
+                            <td>
+                                {grupo.permissoes && grupo.permissoes.length > 0
+                                    ? grupo.permissoes.map((p) => p.nome).join(', ')
+                                    : 'Nenhuma'}
+                            </td>
+                            <td></td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            <Pagination page={page} pageCount={pageCount} changePage={changePage} />
+        </div>
     );
 }
 

--- a/frontend/src/components/TabelaTurmas.js
+++ b/frontend/src/components/TabelaTurmas.js
@@ -1,31 +1,62 @@
+import Pagination from './Pagination';
+import useTableControls from './hooks/useTableControls';
+
 function Tabela({ vetor }) {
+    const {
+        search,
+        setSearch,
+        requestSort,
+        sortConfig,
+        paginated,
+        page,
+        changePage,
+        pageCount,
+    } = useTableControls(vetor, { keys: ['nome', 'ano', 'turno', 'sala', 'nivel'] });
+
+    const getArrow = (key) => {
+        if (sortConfig.key !== key) return '';
+        return sortConfig.direction === 'asc' ? ' \u25B2' : ' \u25BC';
+    };
+
     return (
-        <table className="table">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Nome</th>
-                    <th>Ano</th>
-                    <th>Turno</th>
-                    <th>Sala</th>
-                    <th>Nivel de Ensino</th>
-                    <th>Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                {vetor.map((obj, indice) => (
-                    <tr key={obj.id}>
-                        <td>{indice + 1}</td>
-                        <td>{obj.nome}</td>
-                        <td>{obj.ano}</td>
-                        <td>{obj.turno}</td>
-                        <td>{obj.sala}</td>
-                        <td>{obj.nivel}</td>
-                        <td></td>
+        <div>
+            <div className="d-flex justify-content-end mb-2">
+                <input
+                    type="text"
+                    className="form-control w-auto"
+                    placeholder="Buscar"
+                    value={search}
+                    onChange={(e) => { setSearch(e.target.value); changePage(1); }}
+                />
+            </div>
+            <table className="table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('nome')}>Nome{getArrow('nome')}</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('ano')}>Ano{getArrow('ano')}</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('turno')}>Turno{getArrow('turno')}</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('sala')}>Sala{getArrow('sala')}</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('nivel')}>Nivel de Ensino{getArrow('nivel')}</th>
+                        <th>Ações</th>
                     </tr>
-                ))}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {paginated.map((obj, indice) => (
+                        <tr key={obj.id}>
+                            <td>{(page - 1) * 5 + indice + 1}</td>
+                            <td>{obj.nome}</td>
+                            <td>{obj.ano}</td>
+                            <td>{obj.turno}</td>
+                            <td>{obj.sala}</td>
+                            <td>{obj.nivel}</td>
+                            <td></td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            <Pagination page={page} pageCount={pageCount} changePage={changePage} />
+        </div>
     );
 }
 

--- a/frontend/src/components/TabelaUsuarios.js
+++ b/frontend/src/components/TabelaUsuarios.js
@@ -1,27 +1,58 @@
+import Pagination from './Pagination';
+import useTableControls from './hooks/useTableControls';
+
 function Tabela({ vetor }) {
+    const {
+        search,
+        setSearch,
+        requestSort,
+        sortConfig,
+        paginated,
+        page,
+        changePage,
+        pageCount,
+    } = useTableControls(vetor, { keys: ['nome', 'email'] });
+
+    const getArrow = (key) => {
+        if (sortConfig.key !== key) return '';
+        return sortConfig.direction === 'asc' ? ' \u25B2' : ' \u25BC';
+    };
+
     return (
-        <table className="table">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Nome</th>
-                    <th>Email</th>
-                    <th>Permissão</th>
-                    <th>Ações</th>
-                </tr>
-            </thead>
-            <tbody>
-                {vetor.map((obj, indice) => (
-                    <tr key={obj.id}>
-                        <td>{indice + 1}</td>
-                        <td>{obj.nome}</td>
-                        <td>{obj.email}</td>
-                        <td>{obj.permissaoGrupo.nome}</td>
-                        <td></td>
+        <div>
+            <div className="d-flex justify-content-end mb-2">
+                <input
+                    type="text"
+                    className="form-control w-auto"
+                    placeholder="Buscar"
+                    value={search}
+                    onChange={(e) => { setSearch(e.target.value); changePage(1); }}
+                />
+            </div>
+            <table className="table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('nome')}>Nome{getArrow('nome')}</th>
+                        <th style={{ cursor: 'pointer' }} onClick={() => requestSort('email')}>Email{getArrow('email')}</th>
+                        <th>Permissão</th>
+                        <th>Ações</th>
                     </tr>
-                ))}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {paginated.map((obj, indice) => (
+                        <tr key={obj.id}>
+                            <td>{(page - 1) * 5 + indice + 1}</td>
+                            <td>{obj.nome}</td>
+                            <td>{obj.email}</td>
+                            <td>{obj.permissaoGrupo.nome}</td>
+                            <td></td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            <Pagination page={page} pageCount={pageCount} changePage={changePage} />
+        </div>
     );
 }
 

--- a/frontend/src/components/hooks/useTableControls.js
+++ b/frontend/src/components/hooks/useTableControls.js
@@ -1,0 +1,62 @@
+import { useState, useMemo } from 'react';
+
+export default function useTableControls(data, options = {}) {
+  const [search, setSearch] = useState('');
+  const [sortConfig, setSortConfig] = useState({ key: null, direction: 'asc' });
+  const [page, setPage] = useState(1);
+  const pageSize = options.pageSize || 5;
+
+  const keys = options.keys || (data[0] ? Object.keys(data[0]) : []);
+
+  const filtered = useMemo(() => {
+    if (!search) return data;
+    const lower = search.toLowerCase();
+    return data.filter(item =>
+      keys.some(k => String(item[k]).toLowerCase().includes(lower))
+    );
+  }, [data, search, keys]);
+
+  const sorted = useMemo(() => {
+    if (!sortConfig.key) return filtered;
+    const sortedData = [...filtered].sort((a, b) => {
+      const aVal = a[sortConfig.key];
+      const bVal = b[sortConfig.key];
+      if (aVal < bVal) return sortConfig.direction === 'asc' ? -1 : 1;
+      if (aVal > bVal) return sortConfig.direction === 'asc' ? 1 : -1;
+      return 0;
+    });
+    return sortedData;
+  }, [filtered, sortConfig]);
+
+  const pageCount = Math.ceil(sorted.length / pageSize) || 1;
+
+  const paginated = useMemo(() => {
+    const start = (page - 1) * pageSize;
+    return sorted.slice(start, start + pageSize);
+  }, [sorted, page, pageSize]);
+
+  function requestSort(key) {
+    let direction = 'asc';
+    if (sortConfig.key === key && sortConfig.direction === 'asc') {
+      direction = 'desc';
+    }
+    setSortConfig({ key, direction });
+  }
+
+  function changePage(newPage) {
+    if (newPage < 1 || newPage > pageCount) return;
+    setPage(newPage);
+  }
+
+  return {
+    search,
+    setSearch,
+    sortConfig,
+    requestSort,
+    page,
+    changePage,
+    pageCount,
+    pageSize,
+    paginated,
+  };
+}


### PR DESCRIPTION
## Summary
- add custom hook `useTableControls` with search, sort and pagination logic
- add reusable `Pagination` component for navigation links
- refactor all table components to use the new hook and component
- revert jQuery DataTables integration so rows render normally

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482aedaaa0832087b2da9a2a6f6a79